### PR TITLE
Switch ordering of syncing catalog roles and namespaces.

### DIFF
--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
@@ -630,8 +630,6 @@ public class PolarisSynchronizer {
     }
 
     for (Catalog catalog : catalogSyncPlan.entitiesToSyncChildren()) {
-      syncCatalogRoles(catalog.getName());
-
       IcebergCatalogService sourceIcebergCatalogService;
 
       try {
@@ -666,6 +664,11 @@ public class PolarisSynchronizer {
 
       syncNamespaces(
           catalog.getName(), Namespace.empty(), sourceIcebergCatalogService, targetIcebergCatalogService);
+
+      // NOTE: Grants are synced on a per catalog role basis, so we need to ensure that catalog roles
+      // are only synced AFTER Iceberg catalog entities, because they may depend on the Iceberg catalog
+      // entities already existing
+      syncCatalogRoles(catalog.getName());
     }
   }
 


### PR DESCRIPTION
Because grants are synced per-catalog-role, we need to ensure all the Iceberg entities are migrated over before we can migrate catalog roles. Otherwise, namespace and table level grants will fail to be created. This ordering was correct in the initial implementation, I'm not sure when it got switched around. 