### PR TITLE
CI: Fix artifact-name in case of failure

### DIFF
--- a/.github/workflows/benchmarks-main.yml
+++ b/.github/workflows/benchmarks-main.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: test-results
+          name: test-results-${{ matrix.java-version }}
           path: |
             **/build/reports/*
             **/build/test-results/*

--- a/.github/workflows/iceberg-catalog-migrator-main.yml
+++ b/.github/workflows/iceberg-catalog-migrator-main.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: test-results
+          name: test-results-${{ matrix.java-version }}
           path: |
             **/build/reports/*
             **/build/test-results/*


### PR DESCRIPTION
Matrix jobs cannot share the same artifact-name