### PR TITLE
Disable`If-None-Match` when fetching tables in benchmark scenarios

### DIFF
--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
@@ -184,7 +184,7 @@ case class TableActions(
     http("Fetch Table")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/tables/#{tableName}")
       .header("Authorization", "Bearer #{accessToken}")
-      .header("If-None-Match", null)
+      .header("If-None-Match", "")
       .check(status.is(200))
       .check(jsonPath("$.metadata.table-uuid").saveAs("tableUuid"))
       .check(jsonPath("$.metadata.location").is("#{location}"))

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
@@ -184,6 +184,7 @@ case class TableActions(
     http("Fetch Table")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/tables/#{tableName}")
       .header("Authorization", "Bearer #{accessToken}")
+      .header("If-None-Match", null)
       .check(status.is(200))
       .check(jsonPath("$.metadata.table-uuid").saveAs("tableUuid"))
       .check(jsonPath("$.metadata.location").is("#{location}"))

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
@@ -184,7 +184,6 @@ case class TableActions(
     http("Fetch Table")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/tables/#{tableName}")
       .header("Authorization", "Bearer #{accessToken}")
-      .header("If-None-Match", "")
       .check(status.is(200))
       .check(jsonPath("$.metadata.table-uuid").saveAs("tableUuid"))
       .check(jsonPath("$.metadata.location").is("#{location}"))

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/CreateTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/CreateTreeDataset.scala
@@ -149,6 +149,7 @@ class CreateTreeDataset extends Simulation {
     .baseUrl(cp.baseUrl)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
+    .disableCaching
 
   // Get the configured throughput for tables and views
   private val tableThroughput = wp.createTreeDataset.tableThroughput

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadTreeDataset.scala
@@ -152,6 +152,7 @@ class ReadTreeDataset extends Simulation {
     .baseUrl(cp.baseUrl)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
+    .disableCaching
 
   // Get the configured throughput for tables and views
   private val tableThroughput = wp.readTreeDataset.tableThroughput

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadUpdateTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadUpdateTreeDataset.scala
@@ -142,6 +142,7 @@ class ReadUpdateTreeDataset extends Simulation {
     .baseUrl(cp.baseUrl)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
+    .disableCaching
 
   // Get the configured throughput and duration
   private val throughput = wp.readUpdateTreeDataset.throughput


### PR DESCRIPTION
I found gatling sometimes sending an etag to Polaris during testing, and this explicitly removes it and additionally disables caching for the HTTP protocol.

```
>>>>>>>>>>>>>>>>>>>>>>>>>>
Request:
Fetch Table: KO status.find.is(200), but actually found 304
=========================
Session:
Session(Reader-0-6,9,HashMap(gatling.http.cache.baseUrl -> http://localhost:8181, location -> s3://datalake-storage-team/emaynard/warehouse//C_0/NS_0/NS_2/NS_5/NS_12/NS_26/NS_53/NS_107/NS_216/T_358, catalogName -> C_0, multipartNamespace -> NS_0NS_2NS_5NS_12NS_26NS_53NS_107NS_216, tableUuid -> a2d9e974-1011-4a27-b2a7-27ea1c200d6b, be15ac8d-c58f-4b3f-9284-52615b346c84 -> 126, initialProperties -> HashMap(InitialAttribute_6 -> 6, InitialAttribute_1 -> 1, InitialAttribute_9 -> 9, InitialAttribute_7 -> 7, InitialAttribute_8 -> 8, InitialAttribute_0 -> 0, InitialAttribute_4 -> 4, InitialAttribute_3 -> 3, InitialAttribute_5 -> 5, InitialAttribute_2 -> 2), timestamp.be15ac8d-c58f-4b3f-9284-52615b346c84 -> 1746078977386, accessToken -> ..., gatling.http.cache.dns -> io.gatling.http.resolver.ShufflingNameResolver@5614ae36, gatling.http.cache.contentCache -> io.gatling.core.util.cache.Cache@2c670568, tableName -> T_358, gatling.http.ssl.sslContexts -> io.gatling.http.util.SslContexts@d180b99),KO,...
=========================
HTTP request:
GET http://localhost:8181/api/catalog/v1/C_0/namespaces/NS_0%1FNS_2%1FNS_5%1FNS_12%1FNS_26%1FNS_53%1FNS_107%1FNS_216/tables/T_358
headers:
        accept: application/json
        content-type: application/json
        Authorization: Bearer ...
        host: localhost:8181
        if-none-match: W/"4c5e0c65ecbacdeb95042b8d3a677b35060748a18a48b0cb333d5e5ae9b3aa50"
=========================
HTTP response:
version:
        HTTP/1.1
status:
        304 Not Modified
headers:
        content-encoding: identity
        content-length: 89
        Content-Type: application/json

<<<<<<<<<<<<<<<<<<<<<<<<<

```