### PR TITLE
Small Benchmarks improvements

### DIFF
--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/NAryTreeBuilder.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/NAryTreeBuilder.scala
@@ -48,6 +48,23 @@ case class NAryTreeBuilder(nsWidth: Int, nsDepth: Int) {
     }
 
   /**
+   * Computes the ordinals of all child nodes for a given node.
+   *
+   * @param ordinal the ordinal of the parent node
+   * @return a list of ordinals representing the child nodes
+   */
+  def childrenOf(ordinal: Int): List[Int] = {
+    if (depthOf(ordinal) >= nsDepth - 1) {
+      // Node is a leaf, has no children
+      List.empty
+    } else {
+      // For a node with ordinal p, its children have ordinals: p*nsWidth + 1, p*nsWidth + 2, ..., p*nsWidth + nsWidth
+      val firstChild = ordinal * nsWidth + 1
+      (firstChild until firstChild + nsWidth).toList
+    }
+  }
+
+  /**
    * Calculates the depth of a node in the n-ary tree based on its ordinal.
    *
    * @param ordinal The ordinal of the node.

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/NAryTreeBuilder.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/NAryTreeBuilder.scala
@@ -117,4 +117,21 @@ case class NAryTreeBuilder(nsWidth: Int, nsDepth: Int) {
     val lastLevel = nsDepth - 1
     math.pow(nsWidth, lastLevel).toInt
   }
+
+  /**
+   * Computes the ordinals of all sibling nodes for a given node.
+   *
+   * @param ordinal the ordinal of the node
+   * @return a list of ordinals representing the sibling nodes (excluding the node itself)
+   */
+  def siblingsOf(ordinal: Int): List[Int] =
+    if (ordinal == 0) {
+      // Root node has no siblings
+      List.empty
+    } else {
+      // Get parent ordinal
+      val parent = (ordinal - 1) / nsWidth
+      // Get all children of parent (siblings including self) and exclude self
+      childrenOf(parent).filter(_ != ordinal)
+    }
 }

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/NAryTreeBuilder.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/NAryTreeBuilder.scala
@@ -53,7 +53,7 @@ case class NAryTreeBuilder(nsWidth: Int, nsDepth: Int) {
    * @param ordinal the ordinal of the parent node
    * @return a list of ordinals representing the child nodes
    */
-  def childrenOf(ordinal: Int): List[Int] = {
+  def childrenOf(ordinal: Int): List[Int] =
     if (depthOf(ordinal) >= nsDepth - 1) {
       // Node is a leaf, has no children
       List.empty
@@ -62,7 +62,6 @@ case class NAryTreeBuilder(nsWidth: Int, nsDepth: Int) {
       val firstChild = ordinal * nsWidth + 1
       (firstChild until firstChild + nsWidth).toList
     }
-  }
 
   /**
    * Calculates the depth of a node in the n-ary tree based on its ordinal.

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
@@ -214,7 +214,7 @@ case class NamespaceActions(
 
   val updateNamespaceProperties: ChainBuilder =
     retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update Namespace")(
-      http("Update Namespace")
+      http("Update namespace")
         .post("/api/catalog/v1/#{catalogName}/namespaces/#{namespaceMultipartPath}/properties")
         .header("Authorization", "Bearer #{accessToken}")
         .header("Content-Type", "application/json")

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
@@ -206,7 +206,7 @@ case class NamespaceActions(
    * structure.
    */
   val fetchAllChildrenNamespaces: ChainBuilder = exec(
-    http("Fetch children Namespaces")
+    http("Fetch child namespaces")
       .get("/api/catalog/v1/#{catalogName}/namespaces?parent=#{namespaceMultipartPath}")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
@@ -147,7 +147,7 @@ case class NamespaceActions(
    * Typically, start 1 user and increase by 1 user every second until some arbitrary maximum value.
    */
   val createNamespace: ChainBuilder =
-    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create namespace")(
+    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create Namespace")(
       http("Create Namespace")
         .post("/api/catalog/v1/#{catalogName}/namespaces")
         .header("Authorization", "Bearer #{accessToken}")
@@ -173,7 +173,7 @@ case class NamespaceActions(
    * There is no limit to the number of users that can fetch namespaces concurrently.
    */
   val fetchNamespace: ChainBuilder = exec(
-    http("Fetch Namespace")
+    http("Fetch single Namespace")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{namespaceMultipartPath}")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))
@@ -206,15 +206,15 @@ case class NamespaceActions(
    * structure.
    */
   val fetchAllChildrenNamespaces: ChainBuilder = exec(
-    http("Fetch all Namespaces under specific parent")
+    http("Fetch children Namespaces")
       .get("/api/catalog/v1/#{catalogName}/namespaces?parent=#{namespaceMultipartPath}")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))
   )
 
   val updateNamespaceProperties: ChainBuilder =
-    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update namespace properties")(
-      http("Update Namespace Properties")
+    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update Namespace")(
+      http("Update Namespace")
         .post("/api/catalog/v1/#{catalogName}/namespaces/#{namespaceMultipartPath}/properties")
         .header("Authorization", "Bearer #{accessToken}")
         .header("Content-Type", "application/json")

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
@@ -173,7 +173,7 @@ case class NamespaceActions(
    * There is no limit to the number of users that can fetch namespaces concurrently.
    */
   val fetchNamespace: ChainBuilder = exec(
-    http("Fetch single Namespace")
+    http("Fetch single namespace")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{namespaceMultipartPath}")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
@@ -147,7 +147,7 @@ case class NamespaceActions(
    * Typically, start 1 user and increase by 1 user every second until some arbitrary maximum value.
    */
   val createNamespace: ChainBuilder =
-    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create Namespace")(
+    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create namespace")(
       http("Create Namespace")
         .post("/api/catalog/v1/#{catalogName}/namespaces")
         .header("Authorization", "Bearer #{accessToken}")

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/NamespaceActions.scala
@@ -213,7 +213,7 @@ case class NamespaceActions(
   )
 
   val updateNamespaceProperties: ChainBuilder =
-    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update Namespace")(
+    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update namespace")(
       http("Update namespace")
         .post("/api/catalog/v1/#{catalogName}/namespaces/#{namespaceMultipartPath}/properties")
         .header("Authorization", "Bearer #{accessToken}")

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/TableActions.scala
@@ -149,7 +149,7 @@ case class TableActions(
    *
    * There is no limit to the number of users that can create tables concurrently.
    */
-  val createTable: ChainBuilder = retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create table")(
+  val createTable: ChainBuilder = retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create Table")(
     http("Create Table")
       .post("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/tables")
       .header("Authorization", "Bearer #{accessToken}")
@@ -181,7 +181,7 @@ case class TableActions(
    * There is no limit to the number of users that can fetch tables concurrently.
    */
   val fetchTable: ChainBuilder = exec(
-    http("Fetch Table")
+    http("Fetch single Table")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/tables/#{tableName}")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))
@@ -209,7 +209,7 @@ case class TableActions(
    * given namespace, supporting bulk retrieval of table metadata.
    */
   val fetchAllTables: ChainBuilder = exec(
-    http("Fetch all Tables under parent namespace")
+    http("Fetch children Tables")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/tables")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))
@@ -222,8 +222,8 @@ case class TableActions(
    * There is no limit to the number of users that can update table properties concurrently.
    */
   val updateTable: ChainBuilder =
-    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update table metadata")(
-      http("Update table metadata")
+    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update Table")(
+      http("Update Table")
         .post("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/tables/#{tableName}")
         .header("Authorization", "Bearer #{accessToken}")
         .header("Content-Type", "application/json")

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/ViewActions.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/actions/ViewActions.scala
@@ -134,7 +134,7 @@ case class ViewActions(
       )
     }
 
-  val createView: ChainBuilder = retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create view")(
+  val createView: ChainBuilder = retryOnHttpStatus(maxRetries, retryableHttpCodes, "Create View")(
     http("Create View")
       .post("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/views")
       .header("Authorization", "Bearer #{accessToken}")
@@ -171,7 +171,7 @@ case class ViewActions(
   )
 
   val fetchView: ChainBuilder = exec(
-    http("Fetch View")
+    http("Fetch single View")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/views/#{viewName}")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))
@@ -195,7 +195,7 @@ case class ViewActions(
   )
 
   val fetchAllViews: ChainBuilder = exec(
-    http("Fetch all Views under parent namespace")
+    http("Fetch children Views")
       .get("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/views")
       .header("Authorization", "Bearer #{accessToken}")
       .check(status.is(200))
@@ -208,8 +208,8 @@ case class ViewActions(
    * There is no limit to the number of users that can update table properties concurrently.
    */
   val updateView: ChainBuilder =
-    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update View metadata")(
-      http("Update View metadata")
+    retryOnHttpStatus(maxRetries, retryableHttpCodes, "Update View")(
+      http("Update View")
         .post("/api/catalog/v1/#{catalogName}/namespaces/#{multipartNamespace}/views/#{viewName}")
         .header("Authorization", "Bearer #{accessToken}")
         .header("Content-Type", "application/json")

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadUpdateTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadUpdateTreeDataset.scala
@@ -54,7 +54,6 @@ class ReadUpdateTreeDataset extends Simulation {
   // --------------------------------------------------------------------------------
   // Helper values
   // --------------------------------------------------------------------------------
-  private val numNamespaces: Int = dp.nAryTree.numberOfNodes
   private val accessToken: AtomicReference[String] = new AtomicReference()
   private val shouldRefreshToken: AtomicBoolean = new AtomicBoolean(true)
 
@@ -63,6 +62,21 @@ class ReadUpdateTreeDataset extends Simulation {
   private val nsActions = NamespaceActions(dp, wp, accessToken)
   private val tblActions = TableActions(dp, wp, accessToken)
   private val viewActions = ViewActions(dp, wp, accessToken)
+
+  private val nsListFeeder = new CircularIterator(nsActions.namespaceIdentityFeeder)
+  private val nsExistsFeeder = new CircularIterator(nsActions.namespaceIdentityFeeder)
+  private val nsFetchFeeder = new CircularIterator(nsActions.namespaceFetchFeeder)
+  private val nsUpdateFeeder = nsActions.namespacePropertiesUpdateFeeder()
+
+  private val tblListFeeder = new CircularIterator(tblActions.tableIdentityFeeder)
+  private val tblExistsFeeder = new CircularIterator(tblActions.tableIdentityFeeder)
+  private val tblFetchFeeder = new CircularIterator(tblActions.tableFetchFeeder)
+  private val tblUpdateFeeder = tblActions.propertyUpdateFeeder()
+
+  private val viewListFeeder = new CircularIterator(viewActions.viewIdentityFeeder)
+  private val viewExistsFeeder = new CircularIterator(viewActions.viewIdentityFeeder)
+  private val viewFetchFeeder = new CircularIterator(viewActions.viewFetchFeeder)
+  private val viewUpdateFeeder = viewActions.propertyUpdateFeeder()
 
   // --------------------------------------------------------------------------------
   // Authentication related workloads:
@@ -90,21 +104,6 @@ class ReadUpdateTreeDataset extends Simulation {
         shouldRefreshToken.set(false)
         session
       }
-
-  private val nsListFeeder = new CircularIterator(nsActions.namespaceIdentityFeeder)
-  private val nsExistsFeeder = new CircularIterator(nsActions.namespaceIdentityFeeder)
-  private val nsFetchFeeder = new CircularIterator(nsActions.namespaceFetchFeeder)
-  private val nsUpdateFeeder = nsActions.namespacePropertiesUpdateFeeder()
-
-  private val tblListFeeder = new CircularIterator(tblActions.tableIdentityFeeder)
-  private val tblExistsFeeder = new CircularIterator(tblActions.tableIdentityFeeder)
-  private val tblFetchFeeder = new CircularIterator(tblActions.tableFetchFeeder)
-  private val tblUpdateFeeder = tblActions.propertyUpdateFeeder()
-
-  private val viewListFeeder = new CircularIterator(viewActions.viewIdentityFeeder)
-  private val viewExistsFeeder = new CircularIterator(viewActions.viewIdentityFeeder)
-  private val viewFetchFeeder = new CircularIterator(viewActions.viewFetchFeeder)
-  private val viewUpdateFeeder = viewActions.propertyUpdateFeeder()
 
   // --------------------------------------------------------------------------------
   // Workload: Randomly read and write entities


### PR DESCRIPTION
This PR contains 4 different commits that respectively:

* Add utility methods in the N-ary tree builder to compute the immediate children and sibling nodes of a given ordinal
* Reword the action names to be shorter, so that they are not truncated in Gatling HTML reports
* And a _nit_ code refactor

Each commit can be reviewed separately as they are unrelated.

Note that the utility methods in the N-ary tree builder are not used yet in any simulation.  They will be used in the future when we start talking about data lineage in Polaris to create complex dependencies between views.

Question to reviewers: I have a couple more commits of "general" improvements like these.  I figured I would submit them in another PR to keep this one in the "trivial" range (<100 LoC change).  Is that ok or would you rather have all improvements bundled together?