### PR TITLE
Add missing ASF license

### DIFF
--- a/iceberg-catalog-migrator/LICENSE
+++ b/iceberg-catalog-migrator/LICENSE
@@ -200,3 +200,16 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This product includes a gradle wrapper.
+
+* gradlew
+* gradle/wrapper/gradle-wrapper.properties
+
+Copyright: 2010-2019 Gradle Authors.
+Home page: https://github.com/gradle/gradle
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------


### PR DESCRIPTION
Note for reviewers: the ASF guidelines says that "LICENSE and NOTICE files belong at the top level of the source tree".  But I think it would be akward if there was a LICENCE file at the root of the `polaris-tools` repository but not in any of the tools that are packaged independently.