### PR TITLE
Add missing RAT task in Iceberg catalog migrator

### DIFF
--- a/iceberg-catalog-migrator/build.gradle.kts
+++ b/iceberg-catalog-migrator/build.gradle.kts
@@ -17,10 +17,13 @@
  * under the License.
  */
 
+import org.nosphere.apache.rat.RatTask
+
 plugins {
   `maven-publish`
   signing
   `build-conventions`
+  alias(libs.plugins.rat)
 }
 
 spotless {
@@ -28,4 +31,46 @@ spotless {
     // Must be repeated :( - there's no "addTarget" or so
     target("*.gradle.kts", "buildSrc/*.gradle.kts")
   }
+}
+
+tasks.named<RatTask>("rat").configure {
+  // Gradle
+  excludes.add("**/build/**")
+  excludes.add("gradle/wrapper/gradle-wrapper*")
+  excludes.add(".gradle")
+  excludes.add("**/kotlin-compiler*")
+
+  excludes.add("ide-name.txt")
+  excludes.add("version.txt")
+
+  excludes.add("LICENSE")
+  excludes.add("DISCLAIMER")
+  excludes.add("NOTICE")
+
+  // Eclipse preference files cannot have comments
+  excludes.add("**/*.prefs")
+
+  // Git & GitHub
+  excludes.add(".git")
+  excludes.add(".github/pull_request_template.md")
+
+  // Misc build artifacts
+  excludes.add("**/.keep")
+  excludes.add("logs/**")
+  excludes.add("**/*.lock")
+
+  // Binary files
+  excludes.add("**/*.jar")
+  excludes.add("**/*.zip")
+  excludes.add("**/*.tar.gz")
+  excludes.add("**/*.tgz")
+  excludes.add("**/*.class")
+
+  // IntelliJ
+  excludes.add(".idea")
+  excludes.add("**/*.iml")
+  excludes.add("**/*.iws")
+
+  // Rat can't scan binary images
+  excludes.add("**/*.png")
 }

--- a/iceberg-catalog-migrator/codestyle/intellij-java-google-style.xml
+++ b/iceberg-catalog-migrator/codestyle/intellij-java-google-style.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
 <code_scheme name="GoogleStyle">
   <option name="OTHER_INDENT_OPTIONS">
     <value>

--- a/iceberg-catalog-migrator/gradle/baselibs.versions.toml
+++ b/iceberg-catalog-migrator/gradle/baselibs.versions.toml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # Dependencies needed by buildSrc/
 
 [versions]

--- a/iceberg-catalog-migrator/gradle/libs.versions.toml
+++ b/iceberg-catalog-migrator/gradle/libs.versions.toml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 [versions]
 assertj = "3.27.3"
 aws = "2.30.3" # this is in mapping with iceberg repo.
@@ -61,4 +80,5 @@ slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 errorprone = { id = "net.ltgt.errorprone", version = "4.1.0" }
 nessie-run = { id = "org.projectnessie", version.ref = "nessieRunner" }
 nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
+rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowPlugin" }


### PR DESCRIPTION
This commit also includes adding missing license headers