### PR TITLE
DOC: Fix typo and build instructions

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -140,10 +140,10 @@ For repeated testing and benchmarking purposes it's convenient to have fixed cli
 ```bash
 # Start Polaris with the fixed client-ID/secret admin/admin
 # DO NEVER EVER USE THE FOLLOWING FOR ANY NON-AIRGAPPED POLARIS INSTANCE !!
-./gradlew :polaris-quarkus-server:quarkusBuild &&  java \
+./gradlew :polaris-server:assemble :polaris-server:quarkusAppPartsBuild && java \
   -Dpolaris.bootstrap.credentials=POLARIS,admin,admin \
   -Djava.security.manager=allow \
-  -jar quarkus/server/build/quarkus-app/quarkus-run.jar
+  -jar runtime/server/build/quarkus-app/quarkus-run.jar
 ```
 
 With the above you can run the benchmarks using a configuration file with `client-id = "admin"` and `client-secret = "admin"` - meant only for convenience in a fully airgapped system.
@@ -170,11 +170,11 @@ $$\text{Total number of namespaces} =
 
 The tables are created under the leaves of the tree. That is, they are put under the namespaces with no child namespace. The number of tables that is created under each leaf namespace is configurable. The total number of tables can easily be calculated with the following formulae, where `N` is the tree width, `D` is the total tree depth, and `T` is the number of tables per leaf namespace:
 
-Total number of tables = *N*<sup>*D* − 1</sup> \* *T*
+Total number of tables = *N*<sup>*D* − 1</sup> \* *T*
 
 The views are created alongside the tables. The number of views that is created under each leaf namespace is also configurable. The total number of views can easily be calculated with the following formulae, where `N` is the tree width, `D` is the total tree depth, `V` is the number of views per leaf namespace:
 
-Total number of tables = *N*<sup>*D* − 1</sup> \* *V*
+Total number of tables = *N*<sup>*D* − 1</sup> \* *V*
 
 ## Binary tree example
 
@@ -192,7 +192,7 @@ Using the formula from the previous section, we can calculate the total number o
 
 $$\text{Total number of namespaces} = \frac{2^{3} - 1}{2 - 1} = 7$$
 
-Total number of tables = 2<sup>3 − 1</sup> \* 5 = 20
+Total number of tables = 2<sup>3 − 1</sup> \* 5 = 20
 
 ## 10-ary tree example
 
@@ -210,7 +210,7 @@ Using the formula from the previous section, we can calculate the total number o
 
 $$\text{Total number of namespaces} = \frac{10^{2} - 1}{10 - 1} = 11$$
 
-Total number of tables = 10<sup>2 − 1</sup> \* 3 = 30
+Total number of tables = 10<sup>2 − 1</sup> \* 3 = 30
 
 ## 1-ary tree example
 
@@ -226,9 +226,9 @@ The diagram below shows an example of a test dataset with the following properti
 
 Using the formula from the previous section, we can calculate the total number of namespaces and the total number of tables as follows:
 
-Total number of namespaces = 1000
+Total number of namespaces = 1000
 
-Total number of tables = 1<sup>1000 − 1</sup> \* 7 = 7
+Total number of tables = 1<sup>1000 − 1</sup> \* 7 = 7
 
 ## Size
 

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/WeightedWorkloadOnTreeDatasetParameters.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/WeightedWorkloadOnTreeDatasetParameters.scala
@@ -32,8 +32,8 @@ import scala.util.Random
  * Case class to hold the parameters for the WeightedWorkloadOnTreeDataset simulation.
  *
  * @param seed The RNG seed to use
- * @param readers A seq of distrbutions to use for reading tables
- * @param writers A seq of distrbutions to use for writing to tables
+ * @param readers A seq of distributions to use for reading tables
+ * @param writers A seq of distributions to use for writing to tables
  */
 case class WeightedWorkloadOnTreeDatasetParameters(
     seed: Int,

--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
@@ -84,8 +84,8 @@ public class PolarisSynchronizer {
   /**
    * Calculates the total number of sync tasks to complete.
    *
-   * @param plan the plan to scan for cahnges
-   * @return the nuber of syncs to perform
+   * @param plan the plan to scan for changes
+   * @return the number of syncs to perform
    */
   private int totalSyncsToComplete(SynchronizationPlan<?> plan) {
     return plan.entitiesToCreate().size()

--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/BaseStrategyPlanner.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/BaseStrategyPlanner.java
@@ -78,7 +78,7 @@ public class BaseStrategyPlanner implements SynchronizationPlanner {
    * @param entitiesOnTarget the entities from the target
    * @param requiresOverwrites true if "overwriting" the entity is necessary. Most grant record entities do not need overwriting.
    * @param entityIdentifierSupplier consumes an entity and returns an identifying representation of that entity
-   * @return a {@link SynchronizationPlan} with the entities sorted based on the souce parity strategy
+   * @return a {@link SynchronizationPlan} with the entities sorted based on the source parity strategy
    * @param <T> the type of the entity
    */
   private <T> SynchronizationPlan<T> sortOnIdentifier(


### PR DESCRIPTION
This PR fixes the following:
1. Fix couple typo in the code
2. Fix server build instructions
3. Replace unicodes `<0x2004>` and `<0x2005>` in this case with space