### PR TITLE
Apprunner: migrate to a better maintained maven-plugin-plugin

### DIFF
--- a/apprunner/apprunner-build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
+++ b/apprunner/apprunner-build-logic/src/main/kotlin/publishing/PublishingHelperPlugin.kt
@@ -93,7 +93,6 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       }
 
       apply(plugin = "maven-publish")
-      apply(plugin = "signing")
 
       // Generate a source tarball for a release to be uploaded to
       // https://dist.apache.org/repos/dist/dev/<name>/apache-<name>-<version-with-rc>/
@@ -102,6 +101,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       }
 
       if (isSigningEnabled()) {
+        apply(plugin = "signing")
         plugins.withType<SigningPlugin>().configureEach {
           configure<SigningExtension> {
             val signingKey: String? by project

--- a/apprunner/gradle/libs.versions.toml
+++ b/apprunner/gradle/libs.versions.toml
@@ -32,5 +32,5 @@ soebes-itf-assertj = { module = "com.soebes.itf.jupiter.extension:itf-assertj", 
 soebes-itf-jupiter-extension = { module = "com.soebes.itf.jupiter.extension:itf-jupiter-extension", version.ref = "soebes-itf" }
 
 [plugins]
-maven-plugin = { id = "org.gradlex.maven-plugin-development", version = "1.0.3" }
+maven-plugin = { id = "io.freefair.maven-plugin", version = "9.1.0" }
 rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }

--- a/apprunner/maven-plugin/build.gradle.kts
+++ b/apprunner/maven-plugin/build.gradle.kts
@@ -20,22 +20,26 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
+  // Order of maven-plugin + polaris-apprunner-java matters!
+  id("io.freefair.maven-plugin") version "9.1.0"
   id("polaris-apprunner-java")
-  alias(libs.plugins.maven.plugin)
 }
 
-val deps by configurations.creating
 val maven by configurations.creating
 
-configurations.implementation.get().extendsFrom(deps)
-
 dependencies {
-  deps(project(":polaris-apprunner-common"))
-  implementation(libs.maven.core)
+  implementation(project(":polaris-apprunner-common"))
+
+  compileOnly(libs.maven.core)
   compileOnly(libs.maven.plugin.annotations)
   compileOnly(libs.jakarta.annotation.api)
+
+  testImplementation(libs.maven.core)
   testImplementation(libs.soebes.itf.jupiter.extension)
   testImplementation(libs.soebes.itf.assertj)
+  testCompileOnly(libs.maven.plugin.annotations)
+
+  // Maven distribution for integration tests.
   maven(
     mapOf(
       "group" to "org.apache.maven",
@@ -45,13 +49,6 @@ dependencies {
       "ext" to "tar.gz",
     )
   )
-}
-
-mavenPlugin {
-  helpMojoPackage.set("org.apache.polaris.apprunner.maven")
-  artifactId = project.name
-  groupId = project.group.toString()
-  dependencies = deps
 }
 
 // The following stuff is needed by the Maven integration tests.


### PR DESCRIPTION
It simplifies the build script and is also a pre-requisite for publishing the artifacts.