### PR TITLE
Apprunner: Ensure Maven publishing works

### DIFF
--- a/apprunner/gradle-plugin/build.gradle.kts
+++ b/apprunner/gradle-plugin/build.gradle.kts
@@ -18,8 +18,9 @@
  */
 
 plugins {
-  id("polaris-apprunner-java")
+  // Order of java-gradle-plugin + polaris-apprunner-java matters!
   `java-gradle-plugin`
+  id("polaris-apprunner-java")
 }
 
 dependencies {
@@ -30,7 +31,10 @@ dependencies {
 gradlePlugin {
   plugins {
     register("polaris-apprunner") {
-      id = "org.apache.polaris.apprunner"
+      // This ID becomes the Maven group ID of the Gradle plugin marker artifact.
+      // The artifact ID of the Gradle plugin marker artifact is ID + ".gradle.plugin"
+      // (the defined plugin marker suffix).
+      id = project.group.toString()
       implementationClass = "org.apache.polaris.apprunner.plugin.PolarisRunnerPlugin"
       displayName = "Polaris Runner"
       description = "Start and stop a Polaris server for integration testing"

--- a/apprunner/settings.gradle.kts
+++ b/apprunner/settings.gradle.kts
@@ -67,7 +67,9 @@ dependencyResolutionManagement {
 
 gradle.beforeProject {
   version = baseVersion
-  group = "org.apache.polaris.tools.apprunner"
+  // Note: the Gradle plugin ID is the group ID here. Both should be "aligned",
+  // so that the plugin ID is within this group.
+  group = "org.apache.polaris.apprunner"
 }
 
 val isCI = System.getenv("CI") != null


### PR DESCRIPTION
This change ensures that publishing tasks work correctly, the right `MavenPublications` are being used and no duplicate `MavenPublications` exist.
    
* The Gradle plugin-plugin uses the name `pluginMaven` for the "main" publication. This name is then used instead of the common name `maven`, removing a duplicate (shadowing) publication.
* The Maven plugin-plugin uses the name `mavenJava` for the "main" publication. This name is then used instead of the common name `maven`, removing a duplicate (shadowing) publication.
* The Gradle plugin-plugin adds another publication for the "plugin marker" artifact, which only consists of a pom.xml. Adding the license and parent information to that pom as well.