### PR TITLE
[MCP] chore: Trigger mcp workflow only if changes in mcp

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -29,8 +29,14 @@ name: MCP Server CI
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'mcp-server/**'
+      - '.github/**'    
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'mcp-server/**'
+      - '.github/**'    
 
 env:
   GRADLE_TOS_ACCEPTED: ${{ vars.GRADLE_TOS_ACCEPTED }}


### PR DESCRIPTION
Current mcp will get trigger for all PRs. This will ensure it only get trigger when there is change in GH workflow or in mcp-server.