### PR TITLE
Console: Make Generic Tables Show in the Catalog Explorer

### DIFF
--- a/console/src/components/catalog/TableDetailsDrawer.tsx
+++ b/console/src/components/catalog/TableDetailsDrawer.tsx
@@ -47,12 +47,30 @@ export function TableDetailsDrawer({
 }: TableDetailsDrawerProps) {
   const tableQuery = useQuery({
     queryKey: ["table", catalogName, namespace.join("."), tableName],
-    queryFn: () => tablesApi.get(catalogName, namespace, tableName),
+    queryFn: async () => {
+      // Try to fetch as an Iceberg table first
+      try {
+        return await tablesApi.get(catalogName, namespace, tableName)
+      } catch (icebergError) {
+        // If that fails, try to fetch as a generic table
+        try {
+          return await tablesApi.getGeneric(catalogName, namespace, tableName)
+        } catch (genericError) {
+          // If both fail, throw the original Iceberg error
+          throw icebergError
+        }
+      }
+    },
     enabled: open && !!catalogName && namespace.length > 0 && !!tableName,
   })
 
   const tableData = tableQuery.data
-  const currentSchema = tableData?.metadata.schemas.find(
+
+  // Check if this is a generic table (has 'table' property) or Iceberg table (has 'metadata' property)
+  const isGenericTable = tableData && 'table' in tableData
+  const genericTableData = isGenericTable ? (tableData as any).table : null
+
+  const currentSchema = !isGenericTable && tableData?.metadata?.schemas?.find(
     (s) => s["schema-id"] === tableData.metadata["current-schema-id"]
   )
 
@@ -90,9 +108,71 @@ export function TableDetailsDrawer({
           </div>
         )}
 
-        {tableData && (
+        {tableData && isGenericTable && genericTableData && (
           <div className="mt-6 space-y-6">
-            {/* Table Info */}
+            {/* Generic Table Info */}
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Generic Table Information</h3>
+              <div className="space-y-1 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Name:</span>
+                  <span className="font-mono text-xs">
+                    {genericTableData.name}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Format:</span>
+                  <span>{genericTableData.format}</span>
+                </div>
+                {genericTableData["base-location"] && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Base Location:</span>
+                    <span className="font-mono text-xs break-all">
+                      {genericTableData["base-location"]}
+                    </span>
+                  </div>
+                )}
+                {genericTableData.doc && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Description:</span>
+                    <span className="text-xs break-all">
+                      {genericTableData.doc}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Properties */}
+            {genericTableData.properties &&
+              Object.keys(genericTableData.properties).length > 0 && (
+                <div>
+                  <h3 className="text-sm font-semibold mb-2">Properties</h3>
+                  <div className="border rounded-md">
+                    <div className="divide-y">
+                      {Object.entries(genericTableData.properties).map(
+                        ([key, value]) => (
+                          <div
+                            key={key}
+                            className="px-3 py-2 flex justify-between text-sm"
+                          >
+                            <span className="text-muted-foreground">{key}:</span>
+                            <span className="font-mono text-xs break-all">
+                              {String(value)}
+                            </span>
+                          </div>
+                        )
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+          </div>
+        )}
+
+        {tableData && !isGenericTable && (
+          <div className="mt-6 space-y-6">
+            {/* Iceberg Table Info */}
             <div>
               <h3 className="text-sm font-semibold mb-2">Table Information</h3>
               <div className="space-y-1 text-sm">


### PR DESCRIPTION
# Context
This fixes https://github.com/apache/polaris-tools/issues/111 and allows generic tables to show in the Catalog Explorer in the console.

This uses the same pattern as the TableDetails pattern in https://github.com/adam-christian-software/polaris-tools/commit/126959c6064973afddc30ddc43cac88ca3051902 where the Iceberg Tables and the Generic Tables are shown in the same component.

<img width="564" height="343" alt="image" src="https://github.com/user-attachments/assets/d9e8e7f3-4ee2-4b42-b54b-6ad3610d523e" />
