### PR TITLE
fix: store access tokens in memory instead of localStorage

### DIFF
--- a/console/src/api/auth.ts
+++ b/console/src/api/auth.ts
@@ -120,12 +120,10 @@ export const authApi = {
   },
 
   logout: (): void => {
-    localStorage.removeItem("polaris_access_token")
-    localStorage.removeItem("polaris_realm")
+    apiClient.clearAccessToken()
     // Use a small delay to allow toast to show before redirect
     setTimeout(() => {
       navigate("/login", true)
     }, 100)
   },
 }
-

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -33,6 +33,8 @@ class ApiClient {
   private managementClient: AxiosInstance
   private catalogClient: AxiosInstance
   private polarisClient: AxiosInstance
+  // Store access token in memory only (not in localStorage for security)
+  private accessToken: string | null = null
 
   constructor() {
     this.managementClient = axios.create({
@@ -63,7 +65,7 @@ class ApiClient {
     // Request interceptor to add auth token
     const requestInterceptor = (config: InternalAxiosRequestConfig) => {
       const token = this.getAccessToken()
-      // Read realm from localStorage, fallback to environment variable for backward compatibility
+      // Read realm from localStorage (non-sensitive configuration)
       const realm = localStorage.getItem("polaris_realm") || import.meta.env.VITE_POLARIS_REALM
 
       if (token) {
@@ -107,16 +109,16 @@ class ApiClient {
   }
 
   getAccessToken(): string | null {
-    return localStorage.getItem("polaris_access_token")
+    return this.accessToken
   }
 
   clearAccessToken(): void {
-    localStorage.removeItem("polaris_access_token")
+    this.accessToken = null
     localStorage.removeItem("polaris_realm")
   }
 
   setAccessToken(token: string): void {
-    localStorage.setItem("polaris_access_token", token)
+    this.accessToken = token
   }
 
   getManagementClient(): AxiosInstance {
@@ -133,4 +135,3 @@ class ApiClient {
 }
 
 export const apiClient = new ApiClient()
-

--- a/console/src/hooks/useAuth.tsx
+++ b/console/src/hooks/useAuth.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { createContext, useContext, useState, useEffect, type ReactNode } from "react"
+import { createContext, useContext, useState, type ReactNode } from "react"
 import { toast } from "sonner"
 import { authApi } from "@/api/auth"
 
@@ -32,18 +32,11 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false)
-  const [loading, setLoading] = useState<boolean>(true)
-
-  useEffect(() => {
-    // Check if user is already authenticated
-    const token = localStorage.getItem("polaris_access_token")
-    setIsAuthenticated(!!token)
-    setLoading(false)
-  }, [])
+  const [loading] = useState<boolean>(false)
 
   const login = async (clientId: string, clientSecret: string, realm: string) => {
     try {
-      // Store realm in localStorage
+      // Store realm in localStorage (non-sensitive configuration)
       if (realm) {
         localStorage.setItem("polaris_realm", realm)
       }
@@ -59,8 +52,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     toast.success("Logged out successfully")
     authApi.logout()
     setIsAuthenticated(false)
-    // Clear realm from localStorage on logout
-    localStorage.removeItem("polaris_realm")
   }
 
   return (
@@ -78,4 +69,3 @@ export function useAuth() {
   }
   return context
 }
-


### PR DESCRIPTION
- Replaced localStorage token storage with in-memory storage in ApiClient
- Removed token persistence check from useAuth hook
- Updated logout to use centralized clearAccessToken method
- Tokens are now cleared automatically when browser tab closes
- Prevents XSS attacks from extracting access tokens
- Realm configuration remains in localStorage (non-sensitive)

Fixes #100