### PR TITLE
feat (MCP): Enforce mypy for MCP

### DIFF
--- a/mcp-server/.pre-commit-config.yaml
+++ b/mcp-server/.pre-commit-config.yaml
@@ -37,3 +37,10 @@ repos:
       # Run the formatter.
       - id: ruff-format
         files: ^mcp-server/
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.16.0
+    hooks:
+      - id: mypy
+        args:
+          [--disallow-untyped-defs, --ignore-missing-imports, --install-types, --non-interactive, --follow-imports=skip]
+        files: '(mcp-server/polaris_mcp/.*\.py)|(mcp-server/polaris_mcp/tools/.*\.py)|(mcp-server/tests/.*\.py)|(mcp-server/int_test/.*\.py)'

--- a/mcp-server/int_test/client.py
+++ b/mcp-server/int_test/client.py
@@ -25,6 +25,7 @@ import argparse
 import json
 import sys
 from typing import Any, Optional
+import mcp.types as types
 
 
 class McpClientError(Exception):
@@ -115,7 +116,7 @@ async def _display(result: Any) -> None:
 
 
 async def _run_session(session: Any, args: argparse.Namespace) -> None:
-    def list_tools(tools):
+    def list_tools(tools: types.ListToolsResult) -> None:
         print("Available Tools:")
         for tool in tools:
             print(f"- {tool.name}: {tool.description}")
@@ -184,7 +185,7 @@ async def _run_session(session: Any, args: argparse.Namespace) -> None:
             print(f"Error running tool '{selected_tool.name}': {e}")
 
 
-async def run():
+async def run() -> None:
     parser = argparse.ArgumentParser(description="Polaris MCP Client")
     parser.add_argument(
         "server", help="MCP server. Can be a local .py file, or an HTTP/SSE URL."

--- a/mcp-server/polaris_mcp/server.py
+++ b/mcp-server/polaris_mcp/server.py
@@ -413,7 +413,7 @@ def _call_tool(
 
 
 def _to_tool_result(result: ToolExecutionResult) -> FastMcpToolResult:
-    structured = {"isError": result.is_error}
+    structured: dict[str, Any] = {"isError": result.is_error}
     if result.metadata is not None:
         structured["meta"] = result.metadata
 
@@ -448,7 +448,7 @@ def _coerce_body(body: Any) -> Any:
     return body
 
 
-def _normalize_namespace(namespace: str | Sequence[str]) -> str | list[str]:
+def _normalize_namespace(namespace: str | Sequence) -> str | list[str]:
     if isinstance(namespace, str):
         return namespace
     return [str(part) for part in namespace]

--- a/mcp-server/polaris_mcp/tools/policy.py
+++ b/mcp-server/polaris_mcp/tools/policy.py
@@ -147,31 +147,26 @@ class PolarisPolicyTool(McpTool):
         if isinstance(realm, str) and realm.strip():
             delegate_args["realm"] = realm
 
-        if normalized == "list":
-            self._require_namespace(namespace, "list")
-            self._handle_list(delegate_args, catalog, namespace)
-        elif normalized == "get":
-            self._require_namespace(namespace, "get")
-            self._handle_get(arguments, delegate_args, catalog, namespace)
-        elif normalized == "create":
-            self._require_namespace(namespace, "create")
-            self._handle_create(arguments, delegate_args, catalog, namespace)
-        elif normalized == "update":
-            self._require_namespace(namespace, "update")
-            self._handle_update(arguments, delegate_args, catalog, namespace)
-        elif normalized == "delete":
-            self._require_namespace(namespace, "delete")
-            self._handle_delete(arguments, delegate_args, catalog, namespace)
-        elif normalized == "attach":
-            self._require_namespace(namespace, "attach")
-            self._handle_attach(arguments, delegate_args, catalog, namespace)
-        elif normalized == "detach":
-            self._require_namespace(namespace, "detach")
-            self._handle_detach(arguments, delegate_args, catalog, namespace)
-        elif normalized == "applicable":
+        if normalized == "applicable":
             self._handle_applicable(delegate_args, catalog)
-        else:  # pragma: no cover
-            raise ValueError(f"Unsupported operation: {operation}")
+        else:
+            str_namespace = self._require_namespace(namespace, normalized)
+            if normalized == "list":
+                self._handle_list(delegate_args, catalog, str_namespace)
+            elif normalized == "get":
+                self._handle_get(arguments, delegate_args, catalog, str_namespace)
+            elif normalized == "create":
+                self._handle_create(arguments, delegate_args, catalog, str_namespace)
+            elif normalized == "update":
+                self._handle_update(arguments, delegate_args, catalog, str_namespace)
+            elif normalized == "delete":
+                self._handle_delete(arguments, delegate_args, catalog, str_namespace)
+            elif normalized == "attach":
+                self._handle_attach(arguments, delegate_args, catalog, str_namespace)
+            elif normalized == "detach":
+                self._handle_detach(arguments, delegate_args, catalog, str_namespace)
+            else:  # pragma: no cover
+                raise ValueError(f"Unsupported operation: {operation}")
 
         raw = self._rest_client.call(delegate_args)
         return self._maybe_augment_error(raw, normalized)
@@ -360,11 +355,12 @@ class PolarisPolicyTool(McpTool):
             return "applicable"
         raise ValueError(f"Unsupported operation: {operation}")
 
-    def _require_namespace(self, namespace: Optional[str], operation: str) -> None:
+    def _require_namespace(self, namespace: Optional[str], operation: str) -> str:
         if not namespace:
             raise ValueError(
                 f"Namespace is required for {operation} operations. Provide `namespace` as a string or array."
             )
+        return namespace
 
     def _resolve_namespace(self, namespace: Any) -> str:
         if namespace is None:

--- a/mcp-server/tests/test_config.py
+++ b/mcp-server/tests/test_config.py
@@ -23,6 +23,7 @@ import os
 import textwrap
 from unittest import mock
 from polaris_mcp import server
+from pathlib import Path
 
 
 def test_main_loads_default_config_file() -> None:
@@ -64,7 +65,7 @@ def test_main_loads_custom_config_file() -> None:
         mock_server_instance.run.assert_called_once()
 
 
-def test_config_loading_precedence(tmp_path) -> None:
+def test_config_loading_precedence(tmp_path: Path) -> None:
     config_file = tmp_path / "test_config.env"
     config_file.write_text(
         textwrap.dedent("""

--- a/mcp-server/tests/test_rest_tool.py
+++ b/mcp-server/tests/test_rest_tool.py
@@ -105,6 +105,7 @@ def test_call_builds_request_and_metadata_with_json_body() -> None:
     assert not result.is_error
     assert f"POST {expected_url}" in result.text
     assert '"result": "ok"' in result.text
+    assert result.metadata is not None
     assert result.metadata["method"] == "POST"
     assert result.metadata["url"] == expected_url
     assert result.metadata["status"] == 201
@@ -155,6 +156,7 @@ def test_call_uses_authorization_provider_and_handles_plain_text() -> None:
 
     assert result.is_error
     assert "Status: 404" in result.text
+    assert result.metadata is not None
     assert result.metadata["url"] == expected_url
     assert result.metadata["request"]["bodyText"] == "payload"
     assert result.metadata["response"]["bodyText"] == "failure"

--- a/mcp-server/tests/test_table_tool.py
+++ b/mcp-server/tests/test_table_tool.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import pytest
 from unittest import mock
+from typing import Any
 
 from polaris_mcp.base import ToolExecutionResult
 from polaris_mcp.tools.table import PolarisTableTool
@@ -87,7 +88,7 @@ def test_get_operation_requires_table_argument() -> None:
 
 def test_create_operation_deep_copies_request_body() -> None:
     tool, delegate = _build_tool()
-    body = {"table": "t1", "properties": {"schema-id": 1}}
+    body: dict[str, Any] = {"table": "t1", "properties": {"schema-id": 1}}
     tool.call(
         {
             "operation": "create",


### PR DESCRIPTION
Similar to https://github.com/apache/polaris/pull/3305, enforce mypy for MCP code base.


Here is the before the fix:
```
➜  mcp-server git:(mcp_mypy) ✗ uv run pre-commit run --all-files
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
debug statements (python)................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

mcp-server/polaris_mcp/authorization.py:76: error: Function is missing a type annotation  [no-untyped-def]
mcp-server/polaris_mcp/authorization.py:86: error: Value of type "tuple[str, float] | None" is not indexable  [index]
mcp-server/polaris_mcp/authorization.py:118: error: Incompatible return value type (got "dict[str, str | None]", expected "dict[str, str] | None")  [return-value]
mcp-server/polaris_mcp/authorization.py:123: error: Incompatible return value type (got "dict[str, str | None]", expected "dict[str, str] | None")  [return-value]
mcp-server/polaris_mcp/tools/policy.py:152: error: Argument 3 to "_handle_list" of "PolarisPolicyTool" has incompatible type "str | None"; expected "str"  [arg-type]
mcp-server/polaris_mcp/tools/policy.py:155: error: Argument 4 to "_handle_get" of "PolarisPolicyTool" has incompatible type "str | None"; expected "str"  [arg-type]
mcp-server/polaris_mcp/tools/policy.py:158: error: Argument 4 to "_handle_create" of "PolarisPolicyTool" has incompatible type "str | None"; expected "str"  [arg-type]
mcp-server/polaris_mcp/tools/policy.py:161: error: Argument 4 to "_handle_update" of "PolarisPolicyTool" has incompatible type "str | None"; expected "str"  [arg-type]
mcp-server/polaris_mcp/tools/policy.py:164: error: Argument 4 to "_handle_delete" of "PolarisPolicyTool" has incompatible type "str | None"; expected "str"  [arg-type]
mcp-server/polaris_mcp/tools/policy.py:167: error: Argument 4 to "_handle_attach" of "PolarisPolicyTool" has incompatible type "str | None"; expected "str"  [arg-type]
mcp-server/polaris_mcp/tools/policy.py:170: error: Argument 4 to "_handle_detach" of "PolarisPolicyTool" has incompatible type "str | None"; expected "str"  [arg-type]
mcp-server/polaris_mcp/server.py:418: error: Incompatible types in assignment (expression has type "dict[str, Any]", target has type "bool")  [assignment]
mcp-server/int_test/client.py:118: error: Function is missing a type annotation  [no-untyped-def]
mcp-server/int_test/client.py:187: error: Function is missing a return type annotation  [no-untyped-def]
mcp-server/int_test/client.py:187: note: Use "-> None" if function does not return a value
mcp-server/tests/test_table_tool.py:108: error: Unsupported target for indexed assignment ("Collection[str]")  [index]
mcp-server/tests/test_server.py:90: error: Argument 1 to "_normalize_namespace" has incompatible type "tuple[str, int]"; expected "str | Sequence[str]"  [arg-type]
mcp-server/tests/test_rest_tool.py:108: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:109: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:110: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:111: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:112: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:113: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:114: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:116: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:158: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:159: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:160: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:161: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_rest_tool.py:162: error: Value of type "dict[str, Any] | None" is not indexable  [index]
mcp-server/tests/test_config.py:67: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
Found 30 errors in 8 files (checked 25 source files)
```

And with this PR:
```
➜  mcp-server git:(mcp_mypy) uv run pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
debug statements (python)................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
```