### PR TITLE
MCP: Add mcp nightly publish

### DIFF
--- a/.github/workflows/mcp-server-nightly.yml
+++ b/.github/workflows/mcp-server-nightly.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
+          # The wheel built with Python 3.13 will work for all Python 3.10, 3.11, 3.12, and 3.13 users
           python-version: "3.13"
 
       - name: Install uv


### PR DESCRIPTION
Changes in the PR 
  - Runs daily at 2:00 AM UTC (configurable via cron schedule)
  - Can also be triggered manually via workflow_dispatch
  - Automatically appends a development version suffix (e.g., 0.9.0.dev20231215020000) to avoid version conflicts
  - Uses uv to build and publish the package
  - Publishes to test PyPI using the testpypi index already configured in your pyproject.toml


Secret TEST_PYPI_API_TOKEN has been added to this repo.