### PR TITLE
MCP: Fix the action hash in the nightly publish

### DIFF
--- a/.github/workflows/mcp-server-nightly.yml
+++ b/.github/workflows/mcp-server-nightly.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout Polaris Tools project
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6


### PR DESCRIPTION
Fix this error: 

```
Error: Unable to resolve action `actions/checkout@08c6903cd8c0fde910a37f88322edcb5dd907a8`, unable to find version `08c6903cd8c0fde910a37f88322edcb5dd907a8`
```