### PR TITLE
(nit)MCP: Switch build from setuptools to hatch

### DIFF
--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -51,12 +51,14 @@ homepage = "https://polaris.apache.org/"
 repository = "https://github.com/apache/polaris-tools/"
 
 [build-system]
-requires = ["setuptools>=68.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["polaris_mcp*"]
+[tool.hatch.build.targets.sdist]
+include = ["polaris_mcp"]
+
+[tool.hatch.build.targets.wheel]
+include = ["polaris_mcp"]
 
 [[tool.uv.index]]
 name = "pypi"


### PR DESCRIPTION
Currently we are using setuptools as build system which is very powerful but a bit tedious to use as the project gets complex and it includes a lot more files which are not necessary such as following:

With setuptools:
```sh
➜  dist git:(main) tar -tvzf apache_polaris_mcp-0.9.0.tar.gz
drwxr-xr-x  0 yong   staff       0 Jan 10 16:07 apache_polaris_mcp-0.9.0/
-rw-r--r--  0 yong   staff   11287 Jan 10 16:07 apache_polaris_mcp-0.9.0/PKG-INFO
-rw-r--r--  0 yong   staff   10555 Jan 10 16:07 apache_polaris_mcp-0.9.0/README.md
drwxr-xr-x  0 yong   staff       0 Jan 10 16:07 apache_polaris_mcp-0.9.0/apache_polaris_mcp.egg-info/
-rw-r--r--  0 yong   staff   11287 Jan 10 16:07 apache_polaris_mcp-0.9.0/apache_polaris_mcp.egg-info/PKG-INFO
-rw-r--r--  0 yong   staff     935 Jan 10 16:07 apache_polaris_mcp-0.9.0/apache_polaris_mcp.egg-info/SOURCES.txt
-rw-r--r--  0 yong   staff       1 Jan 10 16:07 apache_polaris_mcp-0.9.0/apache_polaris_mcp.egg-info/dependency_links.txt
-rw-r--r--  0 yong   staff      56 Jan 10 16:07 apache_polaris_mcp-0.9.0/apache_polaris_mcp.egg-info/entry_points.txt
-rw-r--r--  0 yong   staff     129 Jan 10 16:07 apache_polaris_mcp-0.9.0/apache_polaris_mcp.egg-info/requires.txt
-rw-r--r--  0 yong   staff      12 Jan 10 16:07 apache_polaris_mcp-0.9.0/apache_polaris_mcp.egg-info/top_level.txt
drwxr-xr-x  0 yong   staff       0 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/
-rw-r--r--  0 yong   staff     928 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/__init__.py
-rw-r--r--  0 yong   staff    6650 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/authorization.py
-rw-r--r--  0 yong   staff    2340 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/base.py
-rw-r--r--  0 yong   staff   11879 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/rest.py
-rw-r--r--  0 yong   staff   19072 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/server.py
drwxr-xr-x  0 yong   staff       0 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/
-rw-r--r--  0 yong   staff    1361 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/__init__.py
-rw-r--r--  0 yong   staff    7828 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/catalog.py
-rw-r--r--  0 yong   staff   11168 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/catalog_role.py
-rw-r--r--  0 yong   staff   12175 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/namespace.py
-rw-r--r--  0 yong   staff   14948 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/policy.py
-rw-r--r--  0 yong   staff   12155 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/principal.py
-rw-r--r--  0 yong   staff   11289 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/principal_role.py
-rw-r--r--  0 yong   staff    9891 Jan 10 16:07 apache_polaris_mcp-0.9.0/polaris_mcp/tools/table.py
-rw-r--r--  0 yong   staff    1936 Jan 10 16:07 apache_polaris_mcp-0.9.0/pyproject.toml
-rw-r--r--  0 yong   staff      38 Jan 10 16:07 apache_polaris_mcp-0.9.0/setup.cfg
drwxr-xr-x  0 yong   staff       0 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/
-rw-r--r--  0 yong   staff   13164 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_authorization.py
-rw-r--r--  0 yong   staff    2488 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_catalog_role_tool.py
-rw-r--r--  0 yong   staff    2581 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_catalog_tool.py
-rw-r--r--  0 yong   staff    3279 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_config.py
-rw-r--r--  0 yong   staff    2528 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_namespace_tool.py
-rw-r--r--  0 yong   staff    2139 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_policy_tool.py
-rw-r--r--  0 yong   staff    2144 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_principal_role_tool.py
-rw-r--r--  0 yong   staff    2214 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_principal_tool.py
-rw-r--r--  0 yong   staff    7639 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_rest_tool.py
-rw-r--r--  0 yong   staff   13473 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_server.py
-rw-r--r--  0 yong   staff    6562 Jan 10 16:07 apache_polaris_mcp-0.9.0/tests/test_table_tool.py
```

With hatch:
```
➜  dist git:(main) ✗ tar -tvzf apache_polaris_mcp-0.9.0.tar.gz
-rw-r--r--  0 0      0         928 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/__init__.py
-rw-r--r--  0 0      0        6650 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/authorization.py
-rw-r--r--  0 0      0        2340 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/base.py
-rw-r--r--  0 0      0       11879 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/rest.py
-rw-r--r--  0 0      0       19072 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/server.py
-rw-r--r--  0 0      0        1361 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/__init__.py
-rw-r--r--  0 0      0        7828 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/catalog.py
-rw-r--r--  0 0      0       11168 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/catalog_role.py
-rw-r--r--  0 0      0       12175 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/namespace.py
-rw-r--r--  0 0      0       14948 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/policy.py
-rw-r--r--  0 0      0       12155 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/principal.py
-rw-r--r--  0 0      0       11289 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/principal_role.py
-rw-r--r--  0 0      0        9891 Feb  1  2020 apache_polaris_mcp-0.9.0/polaris_mcp/tools/table.py
-rw-r--r--  0 0      0        1704 Feb  1  2020 apache_polaris_mcp-0.9.0/.gitignore
-rw-r--r--  0 0      0       10555 Feb  1  2020 apache_polaris_mcp-0.9.0/README.md
-rw-r--r--  0 0      0        1969 Feb  1  2020 apache_polaris_mcp-0.9.0/pyproject.toml
-rw-r--r--  0 0      0       11287 Feb  1  2020 apache_polaris_mcp-0.9.0/PKG-INFO
```

Also, from https://github.com/apache/polaris/pull/3410, I am switching from `poetry-core` to `hatch` as well.
