### PR TITLE
fix: gitignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ ui/src/generated/
 dist
 dist-ssr
 *.local
+.env
 
 # Eclipse IDE
 .classpath

--- a/console/.env
+++ b/console/.env
@@ -1,4 +1,0 @@
-VITE_POLARIS_API_URL=http://localhost:8181
-VITE_POLARIS_REALM=POLARIS  # optional
-VITE_POLARIS_PRINCIPAL_SCOPE=PRINCIPAL_ROLE:ALL  # optional
-VITE_OAUTH_TOKEN_URL=http://localhost:8181/api/catalog/v1/oauth/tokens


### PR DESCRIPTION
Perhaps .env was delivered by mistake. Usually .env is used to configure local environment during the development process.