### PR TITLE
Top level makefile for services management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,130 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+# Configures the shell for recipes to use bash, enabling bash commands and ensuring
+# that recipes exit on any command failure (including within pipes).
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+##@ General
+
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9\.-]+:.*?##/ { printf "  \033[36m%-40s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Benchmarks
+
+.PHONY: benchmarks-pre-requisite
+benchmarks-pre-requisite:
+	@if [ ! -f "benchmarks/application.conf" ]; then \
+		echo "ERROR: benchmarks/application.conf is missing"; \
+		exit 1; \
+	fi
+
+.PHONY: benchmarks-create-dataset-simulation
+benchmarks-create-dataset-simulation: benchmarks-pre-requisite ## Run create dataset simulation
+	@echo "--- Running create dataset simulation ---"
+	@$(MAKE) -C benchmarks create-dataset-simulation
+	@echo "--- Create dataset simulation completed ---"
+
+.PHONY: benchmarks-read-simulation
+benchmarks-read-simulation: benchmarks-pre-requisite ## Run read simulation
+	@echo "--- Running read simulation ---"
+	@$(MAKE) -C benchmarks read-simulation
+	@echo "--- Read simulation completed ---"
+
+.PHONY: benchmarks-read-update-simulation
+benchmarks-read-update-simulation: benchmarks-pre-requisite ## Run read/update simulation
+	@echo "--- Running read/update simulation ---"
+	@$(MAKE) -C benchmarks read-update-simulation
+	@echo "--- Read/Update simulation completed ---"
+
+.PHONY: benchmarks-create-commits-simulation
+benchmarks-create-commits-simulation: benchmarks-pre-requisite ## Run create commits simulation
+	@echo "--- Running create commits simulation ---"
+	@$(MAKE) -C benchmarks create-commits-simulation
+	@echo "--- Create commits simulation completed ---"
+
+.PHONY: benchmarks-weighted-workload-simulation
+benchmarks-weighted-workload-simulation: benchmarks-pre-requisite ## Run weighted workload simulation
+	@echo "--- Running weighted workload simulation ---"
+	@$(MAKE) -C benchmarks weighted-workload-simulation
+	@echo "--- Weighted workload simulation completed ---"
+
+.PHONY: benchmarks-reports-list
+benchmarks-reports-list: ## List benchmark reports
+	@echo "--- Listing benchmark reports ---"
+	@$(MAKE) -C benchmarks reports-list
+	@echo "--- List benchmark reports completed ---"
+
+.PHONY: benchmarks-reports-clean
+benchmarks-reports-clean: ## Clean benchmark reports
+	@echo "--- Cleaning benchmark reports ---"
+	@$(MAKE) -C benchmarks reports-clean
+	@echo "--- Clean benchmark reports completed ---"
+
+
+##@ Console
+
+.PHONY: console-build-docker
+console-build-docker: ## Build docker image for console project
+	@echo "--- Building docker image for console project---"
+	@$(MAKE) -C console build-docker
+	@echo "--- Docker image for console project built ---"
+
+.PHONY: console-install
+console-install: ## Install dependencies for console project
+	@echo "--- Install dependencies for console project ---"
+	@$(MAKE) -C console install
+	@echo "--- Dependencies for console project completed ---"
+
+.PHONY: console-build
+console-build: console-install ## Build console project
+	@echo "--- Building console project---"
+	@$(MAKE) -C console build
+	@echo "--- Console project built ---"
+
+.PHONY: console-lint
+console-lint: console-install ## Lint the console project
+	@echo "--- Linting the console project ---"
+	@$(MAKE) -C console lint
+	@echo "--- Console project linted ---"
+
+.PHONY: console-lint-fix
+console-lint-fix: console-install ## Fix linting issues in the console project
+	@echo "--- Fixing linting issues in the console project ---"
+	@$(MAKE) -C console lint-fix
+	@echo "--- Linting issues in the console project fixed ---"
+
+.PHONY: console-format-check
+console-format-check: console-install ## Check formatting in the console project
+	@echo "--- Checking formatting in the console project ---"
+	@$(MAKE) -C console format-check
+	@echo "--- Formatting in the console project checked ---"
+
+.PHONY: console-format-fix
+console-format-fix: console-install ## Fix formatting in the console project
+	@echo "--- Fixing formatting in the console project ---"
+	@$(MAKE) -C console format-fix
+	@echo "--- Formatting in the console project fixed ---"
+
+.PHONY: console-dev
+console-dev: console-install ## Run the console project in development mode
+	@echo "--- Running console project in development mode ---"
+	@$(MAKE) -C console dev
+	@echo "--- Console project in development mode completed ---"
+


### PR DESCRIPTION
So currently we have two projects under this repo which are using Makefile. Reading makefile is never fun and a bit more tedious when we have multiple of them. The problems may be a bit more worse as we add more Makefile (e.g. one per project...so we will have five instead of two for current repo).

Also, for the current existed Makefile, they all have their own "pre-requisite" which will prevent other targets to fail (e.g. most of the targets in benchmarks will need `application.conf` and most of the targets in console will need `make install`...which is doing npm install to install dependencies). These can be fix on the individual Makefile or do what I did in this PR to chain these relations on the top level Makefile (so other Makefiles stay the same).

Here is the sample output:
```
➜  polaris-tools git:(top_level_makefile) ✗ make

Usage:
  make <target>

General
  help                                      Display this help

Benchmarks
  benchmarks-create-dataset-simulation      Run create dataset simulation
  benchmarks-read-simulation                Run read simulation
  benchmarks-read-update-simulation         Run read/update simulation
  benchmarks-create-commits-simulation      Run create commits simulation
  benchmarks-weighted-workload-simulation   Run weighted workload simulation
  benchmarks-reports-list                   List benchmark reports
  benchmarks-reports-clean                  Clean benchmark reports

Console
  console-build-docker                      Build docker image for console project
  console-install                           Install dependencies for console project
  console-build                             Build console project
  console-lint                              Lint the console project
  console-lint-fix                          Fix linting issues in the console project
  console-format-check                      Check formatting in the console project
  console-format-fix                        Fix formatting in the console project
  console-dev                               Run the console project in development mode
```

For benchmarks (newly added pre-requisite for checking if config is there):
```shell
# new behavior
➜  polaris-tools git:(top_level_makefile) ✗ make benchmarks-create-dataset-simulation
ERROR: benchmarks/application.conf is missing
make: *** [benchmarks-pre-requisite] Error 1

# original behavior
➜  benchmarks git:(top_level_makefile) ✗ make create-dataset-simulation
./gradlew gatlingRun --simulation org.apache.polaris.benchmarks.simulations.CreateTreeDataset \
      -Dconfig.file=./application.conf

> Task :gatlingRun
21:27:18.847 [ERROR] i.g.a.Gatling$ - Run crashed
java.io.FileNotFoundException: ./application.conf (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:213)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:152)
        at com.typesafe.config.impl.Parseable$ParseableFile.reader(Parseable.java:629)
        at com.typesafe.config.impl.Parseable.reader(Parseable.java:99)
        at com.typesafe.config.impl.Parseable.rawParseValue(Parseable.java:233)
        at com.typesafe.config.impl.Parseable.parseValue(Parseable.java:180)
```

For console (auto make install for deps installation):
```shell
# new behavior
➜  polaris-tools git:(top_level_makefile) ✗ make console-lint
--- Install dependencies for console project ---
npm install

added 337 packages, and audited 338 packages in 3s

80 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
--- Dependencies for console project completed ---
--- Linting the console project ---
npm run format:check

> polaris-console@1.3.0-incubating format:check
> prettier --check "src/**/*.{ts,tsx,js,jsx,json,css,md}"

Checking formatting...
All matched files use Prettier code style!
npm run lint

> polaris-console@1.3.0-incubating lint
> eslint .

--- Console project linted ---

# original behavior
➜  console git:(top_level_makefile) ✗ make lint
npm run format:check

> polaris-console@1.3.0-incubating format:check
> prettier --check "src/**/*.{ts,tsx,js,jsx,json,css,md}"

sh: prettier: command not found
make: *** [format-check] Error 127
```
