### PR TITLE
Feature/reproducible builds console

### DIFF
--- a/console/Makefile
+++ b/console/Makefile
@@ -10,7 +10,7 @@ build-docker:
 
 .PHONY: install
 install:
-	npm install
+	npm ci
 
 .PHONY: lint
 lint: format-check

--- a/console/docker/Dockerfile
+++ b/console/docker/Dockerfile
@@ -28,10 +28,10 @@ ENV VITE_POLARIS_REALM_HEADER_NAME=Polaris-Realm
 WORKDIR /app
 
 # Copy package files
-COPY package.json ./
+COPY package.json package-lock.json ./
 
 # Install dependencies
-RUN npm install
+RUN npm ci
 
 # Copy source code (excluding docker directory via .dockerignore)
 COPY . .

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -29,4 +29,8 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    cssCodeSplit: false,
+    sourcemap: false,
+  },
 })


### PR DESCRIPTION
fixes #95 

- Add devbox.json with pinned Node.js 22.12.0 for reproducible environment
- Update vite.config.ts with deterministic build options
- Update Makefile with reproducible build and verification targets
- Update Dockerfile to use npm ci for deterministic installs
- Pin exact dependency versions in package.json (remove ^ prefix)
- Update README.md with reproducible build documentation



# I have tested and everything is working fine and here is the proof
## Verifying devbox.json 
the nodejs 22.12.0 is available in json content

<img width="1090" height="397" alt="1" src="https://github.com/user-attachments/assets/3c47ce29-6555-4f40-8e0f-07096effe431" />


## Verifying package.json has pinned versions
As there is no ^ prefix in any dependency version so there is no output 

<img width="832" height="61" alt="image-2" src="https://github.com/user-attachments/assets/72018914-53b7-4fa4-9a09-5ddc2dc5b956" />


## Verifying that the npm ci has clean install
<img width="894" height="218" alt="image-3" src="https://github.com/user-attachments/assets/fb1132a3-8911-45e0-8074-a2c0ced584b6" />


## Clean build # 1
<img width="924" height="413" alt="image-4" src="https://github.com/user-attachments/assets/f5cbe848-9414-4eb4-9b32-6cf56bc2bf9f" />


## Build # 1 Sha256 hash
<img width="893" height="48" alt="image-5" src="https://github.com/user-attachments/assets/0ee42116-0c91-4af8-aa55-98a72b0872f8" />

## Clean build # 2
<img width="928" height="395" alt="image-7" src="https://github.com/user-attachments/assets/56921b59-804b-4efa-9993-cce9563ea45f" />

## Build # 2 Sha256 hash
<img width="886" height="105" alt="image-6" src="https://github.com/user-attachments/assets/8ff36168-929f-4c50-b12a-371f50ca27d1" />