### PR TITLE
build(console): add devbox.json for consistent node.js environment

### DIFF
--- a/console/devbox.json
+++ b/console/devbox.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
+  "packages": [
+    "nodejs@22.12.0"
+  ],
+  "shell": {
+    "scripts": {
+      "build": "npm ci && npm run build"
+    }
+  }
+}


### PR DESCRIPTION
changes:
- add devbox.json to pin node.js version for consistent environment

fixes #163