### PR TITLE
Catalog Migrator: Add missing NOTICE entries for non-ASF Apache licensed dependencies

### DIFF
--- a/iceberg-catalog-migrator/cli/BUNDLE-LICENSE
+++ b/iceberg-catalog-migrator/cli/BUNDLE-LICENSE
@@ -1239,6 +1239,13 @@ License: BSD 3-Clause
 
 --------------------------------------------------------------------------------
 
+This artifact bundles iq80 LevelDB (Java port of LevelDB).
+
+Project URL: https://github.com/dain/leveldb
+License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 This artifact bundles Project Nessie.
 
 Project URL: https://github.com/projectnessie/nessie

--- a/iceberg-catalog-migrator/cli/BUNDLE-NOTICE
+++ b/iceberg-catalog-migrator/cli/BUNDLE-NOTICE
@@ -165,3 +165,60 @@ This artifact bundles Netty with the following in its NOTICE:
 |   * HOMEPAGE:
 |     * https://github.com/JCTools/JCTools
 
+-------------------------------------------------------------------------
+
+This artifact bundles Snappy Java with the following in its NOTICE:
+| This product includes software developed by Google Snappy.
+| (http://code.google.com/p/snappy)
+|
+| This product includes software developed by Apache
+| PureJavaCrc32C from apache-hadoop-common.
+| (http://hadoop.apache.org)
+
+-------------------------------------------------------------------------
+
+This artifact bundles HawtJNI with the following in its NOTICE:
+| This product includes software developed by FuseSource Corp.
+| http://fusesource.com
+|
+| This product includes software developed at
+| Progress Software Corporation and/or its subsidiaries or affiliates.
+|
+| This product includes software developed by IBM Corporation and others.
+
+-------------------------------------------------------------------------
+
+This artifact bundles BoneCP with the following in its NOTICE:
+| BoneCP
+| Copyright 2010 Wallace Wadge
+
+-------------------------------------------------------------------------
+
+This artifact bundles Eigenbase Properties with the following in its NOTICE:
+| eigenbase-properties
+| Copyright (C) 2012-2020, Julian Hyde
+| This product includes software from the Eigenbase project, licensed from
+| DynamoBI Corporation.
+| Copyright (C) 2005 Dynamo BI Corporation
+
+-------------------------------------------------------------------------
+
+This artifact bundles Groovy with the following in its NOTICE:
+| Apache Groovy
+| Copyright 2003-2015 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| It includes the following other software:
+|
+| Antlr 2 (http://www.antlr2.org/)
+| ASM (http://asm.ow2.org/)
+| GPars (http://www.gpars.org/)
+| Hamcrest (https://github.com/hamcrest/JavaHamcrest)
+| JCommander (http://jcommander.org/)
+| Openbeans (https://code.google.com/p/openbeans/)
+| QDox (http://qdox.codehaus.org/)
+| TestNG (http://testng.org/)
+| XStream (http://xstream.codehaus.org/)
+


### PR DESCRIPTION
## Summary

- Add NOTICE propagation for 5 non-ASF, Apache 2.0 licensed dependencies that have substantive NOTICE files in their source repos
- Identified during RC verification: Snappy Java and Groovy (Codehaus) were flagged by @jbonofre; HawtJNI, BoneCP, and Eigenbase Properties found via full audit

### Added entries:
- **Snappy Java** (xerial): Google Snappy and Hadoop PureJavaCrc32C attributions ([source NOTICE](https://github.com/xerial/snappy-java/blob/main/NOTICE))
- **HawtJNI** (Fusesource): FuseSource Corp, Progress Software, IBM attributions ([source notice.md](https://github.com/fusesource/hawtjni/blob/master/notice.md))
- **BoneCP** (Jolbox): Copyright 2010 Wallace Wadge ([source NOTICE](https://github.com/wwadge/bonecp/blob/master/NOTICE))
- **Eigenbase Properties**: Copyright Julian Hyde and DynamoBI Corporation ([source NOTICE](https://github.com/julianhyde/eigenbase-properties/blob/master/NOTICE))
- **Groovy** (Codehaus 2.4.4, pre-ASF): Copyright 2003-2015, third-party software list ([source NOTICE](https://github.com/codehaus/groovy-git/blob/master/NOTICE))

## Test plan
- [x] `./gradlew rat` passes
- [x] `./gradlew :iceberg-catalog-migrator-cli:shadowJar` builds successfully
- [x] `META-INF/NOTICE` in the uber jar contains all new entries
- [ ] Reviewer verifies NOTICE content matches upstream source repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)