### PR TITLE
Catalog Migrator: Add missing BUNDLE-NOTICE and BUNDLE-LICENSE entries

### DIFF
--- a/iceberg-catalog-migrator/cli/BUNDLE-LICENSE
+++ b/iceberg-catalog-migrator/cli/BUNDLE-LICENSE
@@ -1239,6 +1239,13 @@ License: BSD 3-Clause
 
 --------------------------------------------------------------------------------
 
+This artifact bundles iq80 LevelDB (Java port of LevelDB).
+
+Project URL: https://github.com/dain/leveldb
+License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 This artifact bundles Project Nessie.
 
 Project URL: https://github.com/projectnessie/nessie

--- a/iceberg-catalog-migrator/cli/BUNDLE-LICENSE
+++ b/iceberg-catalog-migrator/cli/BUNDLE-LICENSE
@@ -571,6 +571,13 @@ License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.
 
 --------------------------------------------------------------------------------
 
+This artifact bundles Amazon S3 Analytics Accelerator.
+
+Project URL: https://github.com/awslabs/analytics-accelerator-s3
+License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 This artifact bundles Codahale Metrics (Dropwizard).
 
 Project URL: https://github.com/dropwizard/metrics
@@ -1239,6 +1246,13 @@ License: BSD 3-Clause
 
 --------------------------------------------------------------------------------
 
+This artifact bundles iq80 LevelDB (Java port of LevelDB).
+
+Project URL: https://github.com/dain/leveldb
+License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 This artifact bundles Project Nessie.
 
 Project URL: https://github.com/projectnessie/nessie
@@ -1305,6 +1319,55 @@ License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.
 This artifact bundles Snappy Java.
 
 Project URL: https://github.com/xerial/snappy-java
+License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+This artifact bundles Google Snappy (via Snappy Java native libraries).
+
+Project URL: https://github.com/google/snappy
+License: BSD 3-Clause
+| Copyright 2011, Google Inc.
+| All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+This artifact bundles libstdc++ with Snappy Java native libraries.
+
+Project URL: https://gcc.gnu.org/onlinedocs/libstdc++/
+License: GCC Runtime Library Exception - http://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html
+
+--------------------------------------------------------------------------------
+
+This artifact bundles Apache Parquet Format (shaded by Amazon S3 Analytics Accelerator).
+
+Project URL: https://github.com/apache/parquet-format
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------

--- a/iceberg-catalog-migrator/cli/BUNDLE-NOTICE
+++ b/iceberg-catalog-migrator/cli/BUNDLE-NOTICE
@@ -165,3 +165,60 @@ This artifact bundles Netty with the following in its NOTICE:
 |   * HOMEPAGE:
 |     * https://github.com/JCTools/JCTools
 
+-------------------------------------------------------------------------
+
+This artifact bundles Snappy Java with the following in its NOTICE:
+| This product includes software developed by Google Snappy.
+| (http://code.google.com/p/snappy)
+|
+| This product includes software developed by Apache
+| PureJavaCrc32C from apache-hadoop-common.
+| (http://hadoop.apache.org)
+
+-------------------------------------------------------------------------
+
+This artifact bundles HawtJNI with the following in its NOTICE:
+| This product includes software developed by FuseSource Corp.
+| http://fusesource.com
+|
+| This product includes software developed at
+| Progress Software Corporation and/or its subsidiaries or affiliates.
+|
+| This product includes software developed by IBM Corporation and others.
+
+-------------------------------------------------------------------------
+
+This artifact bundles BoneCP with the following in its NOTICE:
+| BoneCP
+| Copyright 2010 Wallace Wadge
+
+-------------------------------------------------------------------------
+
+This artifact bundles Eigenbase Properties with the following in its NOTICE:
+| eigenbase-properties
+| Copyright (C) 2012-2020, Julian Hyde
+| This product includes software from the Eigenbase project, licensed from
+| DynamoBI Corporation.
+| Copyright (C) 2005 Dynamo BI Corporation
+
+-------------------------------------------------------------------------
+
+This artifact bundles Groovy with the following in its NOTICE:
+| Apache Groovy
+| Copyright 2003-2015 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| It includes the following other software:
+|
+| Antlr 2 (http://www.antlr2.org/)
+| ASM (http://asm.ow2.org/)
+| GPars (http://www.gpars.org/)
+| Hamcrest (https://github.com/hamcrest/JavaHamcrest)
+| JCommander (http://jcommander.org/)
+| Openbeans (https://code.google.com/p/openbeans/)
+| QDox (http://qdox.codehaus.org/)
+| TestNG (http://testng.org/)
+| XStream (http://xstream.codehaus.org/)
+

--- a/iceberg-catalog-migrator/cli/BUNDLE-NOTICE
+++ b/iceberg-catalog-migrator/cli/BUNDLE-NOTICE
@@ -9,6 +9,32 @@ to the ASF by Dremio Corporation. (https://www.dremio.com/) copyright 2022.
 
 -------------------------------------------------------------------------
 
+This artifact bundles Apache Iceberg with the following in its NOTICE:
+| Apache Iceberg
+| Copyright 2017-2026 The Apache Software Foundation
+| 
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+| 
+| This project includes code from Kite, developed at Cloudera, Inc. with
+| the following copyright notice:
+| 
+| Copyright 2013 Cloudera Inc.
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|   http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+
+-------------------------------------------------------------------------
+
 This artifact bundles reload4j with the following in its NOTICE:
 | Apache log4j
 | Copyright 2007 The Apache Software Foundation
@@ -165,3 +191,90 @@ This artifact bundles Netty with the following in its NOTICE:
 |   * HOMEPAGE:
 |     * https://github.com/JCTools/JCTools
 
+-------------------------------------------------------------------------
+
+This artifact bundles Snappy Java with the following in its NOTICE:
+| This product includes software developed by Google
+|  Snappy: http://code.google.com/p/snappy/ (New BSD License)
+|
+| This product includes software developed by Apache
+|  PureJavaCrc32C from apache-hadoop-common http://hadoop.apache.org/
+|  (Apache 2.0 license)
+|
+| This library contains statically linked libstdc++. This inclusion is allowed by
+| "GCC Runtime Library Exception"
+| http://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html
+|
+| == Contributors ==
+|   * Tatu Saloranta
+|     * Providing benchmark suite
+|   * Alec Wysoker
+|     * Performance and memory usage improvement
+|
+| Third-Party Notices and Licenses:
+|
+| - Hadoop: Apache Hadoop is used as a dependency
+|   License: Apache License 2.0
+|   Source/Reference: https://github.com/apache/hadoop/blob/trunk/NOTICE.txt
+
+-------------------------------------------------------------------------
+
+This artifact bundles Amazon S3 Analytics Accelerator with the following in its NOTICE:
+| Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+-------------------------------------------------------------------------
+
+This artifact bundles Apache Parquet Format, shaded by Amazon S3 Analytics Accelerator,
+with the following in its NOTICE:
+| Apache Parquet Format
+| Copyright 2014 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+-------------------------------------------------------------------------
+
+This artifact bundles HawtJNI with the following in its NOTICE:
+| This product includes software developed by FuseSource Corp.
+| http://fusesource.com
+|
+| This product includes software developed at
+| Progress Software Corporation and/or its subsidiaries or affiliates.
+|
+| This product includes software developed by IBM Corporation and others.
+
+-------------------------------------------------------------------------
+
+This artifact bundles BoneCP with the following in its NOTICE:
+| BoneCP
+| Copyright 2010 Wallace Wadge
+
+-------------------------------------------------------------------------
+
+This artifact bundles Eigenbase Properties with the following in its NOTICE:
+| eigenbase-properties
+| Copyright (C) 2012-2020, Julian Hyde
+| This product includes software from the Eigenbase project, licensed from
+| DynamoBI Corporation.
+| Copyright (C) 2005 Dynamo BI Corporation
+
+-------------------------------------------------------------------------
+
+This artifact bundles Groovy with the following in its NOTICE:
+| Apache Groovy
+| Copyright 2003-2015 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| It includes the following other software:
+|
+| Antlr 2 (http://www.antlr2.org/)
+| ASM (http://asm.ow2.org/)
+| GPars (http://www.gpars.org/)
+| Hamcrest (https://github.com/hamcrest/JavaHamcrest)
+| JCommander (http://jcommander.org/)
+| Openbeans (https://code.google.com/p/openbeans/)
+| QDox (http://qdox.codehaus.org/)
+| TestNG (http://testng.org/)
+| XStream (http://xstream.codehaus.org/)

--- a/iceberg-catalog-migrator/cli/build.gradle.kts
+++ b/iceberg-catalog-migrator/cli/build.gradle.kts
@@ -182,6 +182,7 @@ val shadowJar =
       "META-INF/**/DISCLAIMER",
       "LICENSE*",
       "NOTICE*",
+      "THIRD-PARTY-NOTICES",
       "DISCLAIMER",
       "META-INF/DISCLAIMER",
       "META-INF/ASL2.0",


### PR DESCRIPTION
## Summary

- Add NOTICE propagation for 5 non-ASF, Apache 2.0 licensed dependencies that have substantive NOTICE files in their source repos
- Add iq80 LevelDB as a separate BUNDLE-LICENSE entry

### BUNDLE-NOTICE entries added:
- **Snappy Java** (xerial): Google Snappy and Hadoop PureJavaCrc32C attributions ([source NOTICE](https://github.com/xerial/snappy-java/blob/main/NOTICE))
- **HawtJNI** (Fusesource): FuseSource Corp, Progress Software, IBM attributions ([source notice.md](https://github.com/fusesource/hawtjni/blob/master/notice.md))
- **BoneCP** (Jolbox): Copyright 2010 Wallace Wadge ([source NOTICE](https://github.com/wwadge/bonecp/blob/master/NOTICE))
- **Eigenbase Properties**: Copyright Julian Hyde and DynamoBI Corporation ([source NOTICE](https://github.com/julianhyde/eigenbase-properties/blob/master/NOTICE))
- **Groovy** (Codehaus 2.4.4, pre-ASF): Copyright 2003-2015, third-party software list ([source NOTICE](https://github.com/codehaus/groovy-git/blob/master/NOTICE))

### BUNDLE-LICENSE entry added:
- **iq80 LevelDB** (Java port): Apache 2.0 licensed, classes bundled as `org/iq80/leveldb/*` ([source](https://github.com/dain/leveldb))

## Test plan
- [x] `./gradlew rat` passes
- [x] `./gradlew :iceberg-catalog-migrator-cli:shadowJar` builds successfully
- [x] `META-INF/NOTICE` in the uber jar contains all new entries
- [ ] Reviewer verifies NOTICE content matches upstream source repos