### PR TITLE
feat(console/helm): make httproute sectionName optional

### DIFF
--- a/console/helm/templates/httproute.yaml
+++ b/console/helm/templates/httproute.yaml
@@ -35,7 +35,9 @@ spec:
   parentRefs:
     - name: {{ .Values.httproute.gatewayName}}
       namespace: {{ .Values.httproute.gatewayNamespace }}
+      {{- if .Values.httproute.sectionName }}
       sectionName: {{ .Values.httproute.sectionName }}
+      {{- end }}
   rules:
     # We don't specify a matches block here, so the default is a prefix path match on "/" (match every HTTP request)
     # The backend (Service) to send matching requests to


### PR DESCRIPTION
For the helm chart of the console, make httproute sectionName optional