### PR TITLE
Add header support for benchmark tool

### DIFF
--- a/benchmarks/src/gatling/resources/benchmark-defaults.conf
+++ b/benchmarks/src/gatling/resources/benchmark-defaults.conf
@@ -22,6 +22,14 @@ http {
   # Base URL of the Polaris service
   # Default: "http://localhost:8181"
   base-url = "http://localhost:8181"
+
+  # Additional HTTP headers to include in all requests
+  # Example: To set a realm header for catalog requests:
+  # headers {
+  #   Polaris-Realm = "realm-internal"
+  # }
+  # Default: {}
+  headers {}
 }
 
 # Authentication settings

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/BenchmarkConfig.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/BenchmarkConfig.scala
@@ -20,8 +20,23 @@ package org.apache.polaris.benchmarks.parameters
 
 import com.typesafe.config.{Config, ConfigFactory}
 
+import scala.jdk.CollectionConverters._
+
 object BenchmarkConfig {
   val config: BenchmarkConfig = apply()
+
+  private def readHeaders(http: Config): Map[String, String] = {
+    if (http.hasPath("headers")) {
+      val headersConfig = http.getConfig("headers")
+      val result = collection.mutable.Map[String, String]()
+      headersConfig.entrySet().asScala.foreach { entry =>
+        result(entry.getKey) = headersConfig.getString(entry.getKey)
+      }
+      result.toMap
+    } else {
+      Map.empty[String, String]
+    }
+  }
 
   def apply(): BenchmarkConfig = {
     val config: Config = ConfigFactory.load().withFallback(ConfigFactory.load("benchmark-defaults"))
@@ -32,7 +47,8 @@ object BenchmarkConfig {
     val workload: Config = config.getConfig("workload")
 
     val connectionParams = ConnectionParameters(
-      http.getString("base-url")
+      http.getString("base-url"),
+      readHeaders(http)
     )
 
     val authParams = AuthParameters(

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/ConnectionParameters.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/ConnectionParameters.scala
@@ -23,7 +23,7 @@ package org.apache.polaris.benchmarks.parameters
  *
  * @param baseUrl The base URL of the Polaris service.
  */
-case class ConnectionParameters(baseUrl: String) {
+case class ConnectionParameters(baseUrl: String, headers: Map[String, String] = Map.empty) {
   require(baseUrl != null && baseUrl.nonEmpty, "Base URL cannot be null or empty")
   require(
     baseUrl.startsWith("http://") || baseUrl.startsWith("https://"),

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/CreateCommits.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/CreateCommits.scala
@@ -76,6 +76,7 @@ class CreateCommits extends Simulation {
 
   private val httpProtocol = http
     .baseUrl(cp.baseUrl)
+    .headers(cp.headers)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
 

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/CreateTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/CreateTreeDataset.scala
@@ -118,6 +118,7 @@ class CreateTreeDataset extends Simulation {
   // --------------------------------------------------------------------------------
   private val httpProtocol = http
     .baseUrl(cp.baseUrl)
+    .headers(cp.headers)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
     .disableCaching

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadTreeDataset.scala
@@ -120,6 +120,7 @@ class ReadTreeDataset extends Simulation {
   // --------------------------------------------------------------------------------
   private val httpProtocol = http
     .baseUrl(cp.baseUrl)
+    .headers(cp.headers)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
     .disableCaching

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadUpdateTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/ReadUpdateTreeDataset.scala
@@ -109,6 +109,7 @@ class ReadUpdateTreeDataset extends Simulation {
   // --------------------------------------------------------------------------------
   private val httpProtocol = http
     .baseUrl(cp.baseUrl)
+    .headers(cp.headers)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
     .disableCaching

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/WeightedWorkloadOnTreeDataset.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/simulations/WeightedWorkloadOnTreeDataset.scala
@@ -76,6 +76,7 @@ class WeightedWorkloadOnTreeDataset extends Simulation {
   // --------------------------------------------------------------------------------
   private val httpProtocol = http
     .baseUrl(cp.baseUrl)
+    .headers(cp.headers)
     .acceptHeader("application/json")
     .contentTypeHeader("application/json")
     .disableCaching


### PR DESCRIPTION
As requested by https://github.com/apache/polaris-tools/issues/199, this PR adds header support for benchmark tool which will allow users to select target realm for running the benchmark.