### PR TITLE
feat(Console): Add quick setup feature

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "lucide-react": "^0.548.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.9.2",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",

--- a/console/src/components/forms/QuickSetupWizard.tsx
+++ b/console/src/components/forms/QuickSetupWizard.tsx
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { buildSteps, executeSetup, type SetupStep, type SetupResult } from "@/lib/setup-executor"
+import { PRESETS, type Preset } from "@/lib/setup-presets"
+import type { SetupConfig } from "@/types/setup-config"
+import { ModeStep, PresetStep, ParamsStep, ReviewStep } from "./quick-setup/setup-steps"
+import { YamlStep } from "./quick-setup/YamlStep"
+import { ApplyStep, DoneStep } from "./quick-setup/progress-steps"
+
+type WizardStep = "mode" | "preset" | "params" | "yaml" | "review" | "applying" | "done"
+
+const DIALOG_TITLES: Record<WizardStep, string> = {
+  mode: "Quick Setup",
+  preset: "Choose a Preset",
+  params: "Configure Storage",
+  yaml: "Paste Custom YAML",
+  review: "Review Actions",
+  applying: "Applying Configuration",
+  done: "Setup Complete",
+}
+
+interface QuickSetupWizardProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function QuickSetupWizard({ open, onOpenChange }: QuickSetupWizardProps) {
+  const queryClient = useQueryClient()
+
+  const [step, setStep] = useState<WizardStep>("mode")
+  const [mode, setMode] = useState<"preset" | "yaml">("preset")
+  const [selectedPreset, setSelectedPreset] = useState<Preset>(PRESETS[0])
+  const [params, setParams] = useState<Record<string, string>>({})
+  const [config, setConfig] = useState<SetupConfig | null>(null)
+  const [applySteps, setApplySteps] = useState<SetupStep[]>([])
+  const [result, setResult] = useState<SetupResult | null>(null)
+  const [isApplying, setIsApplying] = useState(false)
+
+  const reset = () => {
+    setStep("mode")
+    setMode("preset")
+    setSelectedPreset(PRESETS[0])
+    setParams({})
+    setConfig(null)
+    setApplySteps([])
+    setResult(null)
+    setIsApplying(false)
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isApplying) return
+    if (!nextOpen) reset()
+    onOpenChange(nextOpen)
+  }
+
+  const handleSelectMode = (m: "preset" | "yaml") => {
+    setMode(m)
+    setStep(m === "preset" ? "preset" : "yaml")
+  }
+
+  const loadConfig = (preset: Preset, p: Record<string, string>) => {
+    const resolved = preset.buildConfig(p)
+    setConfig(resolved)
+    setApplySteps(buildSteps(resolved))
+    setStep("review")
+  }
+
+  const handleNextFromPreset = () => {
+    if (selectedPreset.params.length > 0) {
+      setStep("params")
+      return
+    }
+    loadConfig(selectedPreset, {})
+  }
+
+  const handleNextFromParams = () => loadConfig(selectedPreset, params)
+
+  const handleNextFromYaml = (parsed: SetupConfig) => {
+    setConfig(parsed)
+    setApplySteps(buildSteps(parsed))
+    setStep("review")
+  }
+
+  const handleApply = async () => {
+    if (!config) return
+    setStep("applying")
+    setIsApplying(true)
+    try {
+      const setupResult = await executeSetup(config, setApplySteps)
+      setResult(setupResult)
+      queryClient.invalidateQueries()
+    } catch (e) {
+      toast.error("Setup failed", { description: e instanceof Error ? e.message : String(e) })
+    } finally {
+      setIsApplying(false)
+      setStep("done")
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="flex max-h-[90vh] max-w-2xl flex-col overflow-hidden">
+        <DialogHeader className="shrink-0">
+          <DialogTitle>{DIALOG_TITLES[step]}</DialogTitle>
+          {step === "mode" && (
+            <DialogDescription>
+              Bootstrap a Polaris environment using a preset or your own YAML config.
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {step === "mode" && <ModeStep onSelect={handleSelectMode} />}
+
+          {step === "preset" && (
+            <PresetStep
+              selected={selectedPreset}
+              onSelect={setSelectedPreset}
+              onBack={() => setStep("mode")}
+              onNext={handleNextFromPreset}
+            />
+          )}
+
+          {step === "params" && (
+            <ParamsStep
+              preset={selectedPreset}
+              params={params}
+              onChange={setParams}
+              onBack={() => setStep("preset")}
+              onNext={handleNextFromParams}
+            />
+          )}
+
+          {step === "yaml" && (
+            <YamlStep onBack={() => setStep("mode")} onNext={handleNextFromYaml} />
+          )}
+
+          {step === "review" && applySteps.length > 0 && (
+            <ReviewStep
+              steps={applySteps}
+              onBack={() =>
+                setStep(
+                  mode === "yaml" ? "yaml" : selectedPreset.params.length > 0 ? "params" : "preset"
+                )
+              }
+              onApply={handleApply}
+            />
+          )}
+
+          {step === "applying" && <ApplyStep steps={applySteps} isApplying={isApplying} />}
+
+          {(step === "done" || (step === "applying" && !isApplying)) && (
+            <DoneStep
+              steps={applySteps}
+              result={result ?? { credentials: [] }}
+              onDone={() => handleOpenChange(false)}
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/console/src/components/forms/quick-setup/YamlStep.tsx
+++ b/console/src/components/forms/quick-setup/YamlStep.tsx
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState, useEffect, useRef } from "react"
+import { load as parseYaml } from "js-yaml"
+import { CheckCircle2, AlertCircle, Upload } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { DialogFooter } from "@/components/ui/dialog"
+import type { SetupConfig } from "@/types/setup-config"
+
+type ParseResult = { config: SetupConfig; entityCount: number } | { error: string }
+
+interface Props {
+  onBack: () => void
+  onNext: (config: SetupConfig) => void
+}
+
+function parseConfig(text: string): ParseResult {
+  try {
+    const parsed = parseYaml(text)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { error: "YAML must be a mapping object (not a list or scalar)" }
+    }
+    const cfg = parsed as SetupConfig
+    const entityCount =
+      (cfg.principal_roles?.length ?? 0) +
+      Object.keys(cfg.principals ?? {}).length +
+      (cfg.catalogs?.length ?? 0)
+    if (entityCount === 0) {
+      return { error: "No principal_roles, principals, or catalogs found" }
+    }
+    return { config: cfg, entityCount }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+export function YamlStep({ onBack, onNext }: Props) {
+  const [text, setText] = useState("")
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [parseResult, setParseResult] = useState<ParseResult | null>(null)
+
+  useEffect(() => {
+    if (!text.trim()) {
+      setParseResult(null)
+      return
+    }
+    setParseResult(parseConfig(text))
+  }, [text])
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => setText(reader.result as string)
+    reader.readAsText(file)
+    e.target.value = ""
+  }
+
+  const valid = parseResult && "config" in parseResult
+
+  return (
+    <>
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-sm text-muted-foreground">Paste a YAML config.</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="mr-2 h-3.5 w-3.5" />
+            Upload File
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".yaml,.yml"
+            className="hidden"
+            onChange={handleFile}
+          />
+        </div>
+
+        <div className="rounded-lg bg-muted/40 p-4 space-y-2">
+          <Textarea
+            className="font-mono text-xs min-h-56 resize-y bg-background border-border"
+            placeholder={
+              "principal_roles:\n  - my_role\nprincipals:\n  my_user:\n    roles:\n      - my_role\ncatalogs:\n  - name: my_catalog\n    storage_type: file\n    ..."
+            }
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+
+          {parseResult && (
+            <div
+              className={`flex items-center gap-2 text-sm ${valid ? "text-green-600" : "text-destructive"}`}
+            >
+              {valid ? (
+                <>
+                  <CheckCircle2 className="h-4 w-4 shrink-0" />
+                  <span>
+                    Valid — {(parseResult as { entityCount: number }).entityCount} top-level
+                    entities detected
+                  </span>
+                </>
+              ) : (
+                <>
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  <span className="truncate">{(parseResult as { error: string }).error}</span>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+      <DialogFooter className="sticky bottom-0 bg-background pt-4 mt-4 border-t">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button
+          disabled={!valid}
+          onClick={() => onNext((parseResult as { config: SetupConfig }).config)}
+        >
+          Preview →
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/console/src/components/forms/quick-setup/progress-steps.tsx
+++ b/console/src/components/forms/quick-setup/progress-steps.tsx
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  CheckCircle2,
+  AlertCircle,
+  Circle,
+  Copy,
+  Loader2,
+  SkipForward,
+  XCircle,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { DialogFooter } from "@/components/ui/dialog"
+import type { SetupStep, SetupResult } from "@/lib/setup-executor"
+
+// ---------------------------------------------------------------------------
+// StepList — shared progress list used by ApplyStep and DoneStep
+// ---------------------------------------------------------------------------
+
+const STATUS_ICON: Record<SetupStep["status"], React.ReactNode> = {
+  pending: <Circle className="h-4 w-4 text-muted-foreground" />,
+  running: <Loader2 className="h-4 w-4 animate-spin text-blue-500" />,
+  done: <CheckCircle2 className="h-4 w-4 text-green-500" />,
+  skipped: <SkipForward className="h-4 w-4 text-yellow-500" />,
+  error: <XCircle className="h-4 w-4 text-destructive" />,
+}
+
+interface StepListProps {
+  steps: SetupStep[]
+}
+
+export function StepList({ steps }: StepListProps) {
+  return (
+    <div className="space-y-1.5 max-h-64 overflow-y-auto rounded-md border p-3">
+      {steps.map((step) => (
+        <div key={step.id} className="flex items-start gap-2 text-sm">
+          <span className="mt-0.5 shrink-0">{STATUS_ICON[step.status]}</span>
+          <span className={step.status === "error" ? "text-destructive" : ""}>
+            {step.label}
+            {step.status === "skipped" && step.error && (
+              <span className="text-muted-foreground text-xs"> — {step.error}</span>
+            )}
+            {step.status === "error" && step.error && (
+              <span className="block text-xs text-muted-foreground">
+                {typeof step.error === "string" ? step.error : JSON.stringify(step.error)}
+              </span>
+            )}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ApplyStep
+// ---------------------------------------------------------------------------
+
+interface ApplyStepProps {
+  steps: SetupStep[]
+  isApplying: boolean
+}
+
+export function ApplyStep({ steps, isApplying }: ApplyStepProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {isApplying && <Loader2 className="h-4 w-4 animate-spin" />}
+        <span>{isApplying ? "Setting up your Polaris environment…" : "Finishing up…"}</span>
+      </div>
+      <StepList steps={steps} />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// DoneStep
+// ---------------------------------------------------------------------------
+
+interface DoneStepProps {
+  steps: SetupStep[]
+  result: SetupResult
+  onDone: () => void
+}
+
+export function DoneStep({ steps, result, onDone }: DoneStepProps) {
+  const hasErrors = steps.some((s) => s.status === "error" || s.status === "pending")
+  const counts = steps.reduce(
+    (acc, s) => {
+      acc[s.status] = (acc[s.status] ?? 0) + 1
+      return acc
+    },
+    {} as Record<string, number>
+  )
+  const {
+    done: doneCount = 0,
+    skipped: skippedCount = 0,
+    error: errorCount = 0,
+    pending: pendingCount = 0,
+  } = counts
+  const totalResolved = doneCount + skippedCount + errorCount
+
+  return (
+    <>
+      <div className="space-y-4">
+        <div
+          className={`flex items-center gap-2 ${hasErrors ? "text-yellow-600" : "text-green-600"}`}
+        >
+          {hasErrors ? (
+            <AlertCircle className="h-5 w-5 shrink-0" />
+          ) : (
+            <CheckCircle2 className="h-5 w-5 shrink-0" />
+          )}
+          <span className="font-medium text-sm">
+            {pendingCount > 0
+              ? `Setup stopped early — ${doneCount} created, ${skippedCount} skipped, ${errorCount} failed, ${pendingCount} not reached`
+              : hasErrors
+                ? `Setup finished with errors — ${doneCount} created, ${skippedCount} skipped, ${errorCount} failed`
+                : `Setup complete — ${doneCount} created, ${skippedCount} skipped (${totalResolved} total)`}
+          </span>
+        </div>
+
+        <StepList steps={steps} />
+
+        {result.credentials.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">
+              Credentials{" "}
+              <span className="text-muted-foreground font-normal text-xs">
+                (save these now — they won&apos;t be shown again)
+              </span>
+            </p>
+            {result.credentials.map((cred) => (
+              <CredentialsCard key={cred.principalName} cred={cred} />
+            ))}
+          </div>
+        )}
+      </div>
+      <DialogFooter className="sticky bottom-0 bg-background pt-4 mt-4 border-t">
+        <Button onClick={onDone}>Close</Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// CredentialsCard — only used by DoneStep
+// ---------------------------------------------------------------------------
+
+function CredentialRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground w-24 shrink-0">{label}</span>
+      <code className="text-xs bg-background rounded px-1.5 py-0.5 flex-1 truncate">{value}</code>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7"
+        onClick={() => navigator.clipboard.writeText(value).catch(() => null)}
+      >
+        <Copy className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}
+
+interface CredentialsCardProps {
+  cred: SetupResult["credentials"][number]
+}
+
+function CredentialsCard({ cred }: CredentialsCardProps) {
+  return (
+    <Card className="bg-muted/50 border">
+      <CardContent className="pt-4 space-y-2 text-sm">
+        <p className="font-medium">{cred.principalName}</p>
+        <CredentialRow label="Client ID:" value={cred.clientId} />
+        <CredentialRow label="Client Secret:" value={cred.clientSecret} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/console/src/components/forms/quick-setup/setup-steps.tsx
+++ b/console/src/components/forms/quick-setup/setup-steps.tsx
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Wand2, FileCode2 } from "lucide-react"
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { DialogFooter } from "@/components/ui/dialog"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { cn } from "@/lib/utils"
+import { PRESETS, type Preset } from "@/lib/setup-presets"
+import type { SetupStep } from "@/lib/setup-executor"
+
+// ---------------------------------------------------------------------------
+// StepFooter — shared footer used by PresetStep, ParamsStep, and ReviewStep
+// ---------------------------------------------------------------------------
+
+function StepFooter({
+  onBack,
+  onNext,
+  nextLabel = "Next →",
+  disabled = false,
+}: {
+  onBack: () => void
+  onNext: () => void
+  nextLabel?: string
+  disabled?: boolean
+}) {
+  return (
+    <DialogFooter className="sticky bottom-0 bg-background pt-4 mt-4 border-t">
+      <Button variant="outline" onClick={onBack}>
+        Back
+      </Button>
+      <Button onClick={onNext} disabled={disabled}>
+        {nextLabel}
+      </Button>
+    </DialogFooter>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ModeStep
+// ---------------------------------------------------------------------------
+
+function ModeCard({
+  icon: Icon,
+  title,
+  description,
+  mode,
+  onSelect,
+}: {
+  icon: React.ElementType
+  title: string
+  description: string
+  mode: "preset" | "yaml"
+  onSelect: (m: "preset" | "yaml") => void
+}) {
+  return (
+    <Card
+      className="cursor-pointer border-2 hover:border-primary transition-colors"
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(mode)}
+      onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onSelect(mode)}
+    >
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Icon className="h-5 w-5 text-primary" />
+          {title}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+    </Card>
+  )
+}
+
+interface ModeStepProps {
+  onSelect: (mode: "preset" | "yaml") => void
+}
+
+export function ModeStep({ onSelect }: ModeStepProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4 py-2">
+      <ModeCard
+        icon={Wand2}
+        title="Use a Preset"
+        description="Pick from ready-made configurations. Great for getting started quickly."
+        mode="preset"
+        onSelect={onSelect}
+      />
+      <ModeCard
+        icon={FileCode2}
+        title="Use Custom YAML"
+        description="Paste or upload a YAML config"
+        mode="yaml"
+        onSelect={onSelect}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// PresetStep
+// ---------------------------------------------------------------------------
+
+const STORAGE_LABELS: Record<Preset["storageType"], string> = {
+  file: "Local File",
+  s3: "AWS S3",
+  azure: "Azure ADLS",
+  gcs: "Google Cloud",
+}
+
+interface PresetStepProps {
+  selected: Preset
+  onSelect: (preset: Preset) => void
+  onBack: () => void
+  onNext: () => void
+}
+
+export function PresetStep({ selected, onSelect, onBack, onNext }: PresetStepProps) {
+  return (
+    <>
+      <div className="space-y-2">
+        {PRESETS.map((preset) => (
+          <div
+            key={preset.id}
+            role="button"
+            tabIndex={0}
+            className={cn(
+              "flex items-start justify-between rounded-lg border-2 p-4 cursor-pointer transition-colors",
+              selected.id === preset.id
+                ? "border-primary bg-primary/5"
+                : "border-border hover:border-muted-foreground/60"
+            )}
+            onClick={() => onSelect(preset)}
+            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onSelect(preset)}
+          >
+            <div className="space-y-1 pr-4">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-sm">{preset.label}</span>
+                {preset.badge && (
+                  <Badge variant="secondary" className="text-xs">
+                    {preset.badge}
+                  </Badge>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">{preset.description}</p>
+            </div>
+            <Badge variant="outline" className="shrink-0 text-xs">
+              {STORAGE_LABELS[preset.storageType] ?? preset.storageType}
+            </Badge>
+          </div>
+        ))}
+      </div>
+      <StepFooter onBack={onBack} onNext={onNext} />
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ParamsStep
+// ---------------------------------------------------------------------------
+
+interface ParamsStepProps {
+  preset: Preset
+  params: Record<string, string>
+  onChange: (params: Record<string, string>) => void
+  onBack: () => void
+  onNext: () => void
+}
+
+export function ParamsStep({ preset, params, onChange, onBack, onNext }: ParamsStepProps) {
+  const allRequiredFilled = preset.params.every((p) => !p.required || !!params[p.key]?.trim())
+
+  return (
+    <>
+      <div className="rounded-lg bg-muted/40 p-4 space-y-4">
+        {preset.params.map((param) => (
+          <div key={param.key} className="space-y-1.5">
+            <Label htmlFor={param.key}>
+              {param.label}
+              {param.required && <span className="text-destructive ml-1">*</span>}
+            </Label>
+            <Input
+              id={param.key}
+              placeholder={param.placeholder}
+              value={params[param.key] ?? ""}
+              className="bg-background border-border"
+              onChange={(e) => onChange({ ...params, [param.key]: e.target.value })}
+            />
+          </div>
+        ))}
+      </div>
+      <StepFooter onBack={onBack} onNext={onNext} disabled={!allRequiredFilled} />
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ReviewStep
+// ---------------------------------------------------------------------------
+
+interface ReviewStepProps {
+  steps: SetupStep[]
+  onBack: () => void
+  onApply: () => void
+}
+
+export function ReviewStep({ steps, onBack, onApply }: ReviewStepProps) {
+  return (
+    <>
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          The following actions will be performed. Existing entities are skipped automatically.
+        </p>
+        <div className="rounded-md border max-h-72 overflow-y-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {steps.map((step) => (
+                <TableRow key={step.id}>
+                  <TableCell className="text-sm">{step.label}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        <p className="text-xs text-muted-foreground">{steps.length} action(s) planned</p>
+      </div>
+      <StepFooter onBack={onBack} onNext={onApply} nextLabel="Apply Configuration" />
+    </>
+  )
+}

--- a/console/src/lib/setup-executor.ts
+++ b/console/src/lib/setup-executor.ts
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { catalogsApi } from "@/api/management/catalogs"
+import { principalsApi } from "@/api/management/principals"
+import { principalRolesApi } from "@/api/management/principal-roles"
+import { catalogRolesApi } from "@/api/management/catalog-roles"
+import { privilegesApi } from "@/api/management/privileges"
+import { namespacesApi } from "@/api/catalog/namespaces"
+import type { StorageConfigInfo, CatalogPrivilege, NamespacePrivilege } from "@/types/api"
+import type { SetupConfig, CatalogSetupConfig } from "@/types/setup-config"
+
+export interface SetupStep {
+  id: string
+  label: string
+  status: "pending" | "running" | "done" | "skipped" | "error"
+  error?: string
+}
+
+export interface SetupResult {
+  credentials: Array<{
+    principalName: string
+    clientId: string
+    clientSecret: string
+  }>
+}
+
+export type StepUpdateCallback = (steps: SetupStep[]) => void
+
+export async function executeSetup(
+  config: SetupConfig,
+  onStepUpdate: StepUpdateCallback
+): Promise<SetupResult> {
+  const credentials: SetupResult["credentials"] = []
+  const steps = buildSteps(config)
+  onStepUpdate([...steps])
+
+  const update = (id: string, status: SetupStep["status"], error?: string) => {
+    const step = steps.find((s) => s.id === id)
+    if (step) {
+      step.status = status
+      step.error = error
+      onStepUpdate([...steps])
+    }
+  }
+
+  const tryStep = async (id: string, fn: () => Promise<unknown>) => {
+    update(id, "running")
+    try {
+      await fn()
+      update(id, "done")
+    } catch (e) {
+      update(
+        id,
+        isConflict(e) ? "skipped" : "error",
+        isConflict(e) ? undefined : extractErrorMessage(e)
+      )
+    }
+  }
+
+  // On a fatal error (e.g. 403 on initial list calls) mark every unfinished step so
+  // the UI always reaches the "done" screen with a meaningful error state.
+  const failRemaining = (message: string) => {
+    for (const s of steps) {
+      if (s.status === "pending" || s.status === "running") {
+        s.status = "error"
+        s.error = message
+      }
+    }
+    onStepUpdate([...steps])
+  }
+
+  // Mark all still-pending sub-steps of a catalog as skipped (used when the catalog itself fails).
+  const skipCatalogSubSteps = (catalogConfig: CatalogSetupConfig) => {
+    const catalogName = catalogConfig.name
+    for (const [roleName, roleConfig] of Object.entries(catalogConfig.roles ?? {})) {
+      update(`cr-${catalogName}-${roleName}`, "skipped", "catalog creation failed")
+      for (const p of roleConfig.privileges?.catalog ?? []) {
+        update(
+          `grant-catalog-${catalogName}-${roleName}-${p}`,
+          "skipped",
+          "catalog creation failed"
+        )
+      }
+      for (const [ns, privs] of Object.entries(roleConfig.privileges?.namespace ?? {})) {
+        for (const p of privs) {
+          update(
+            `grant-ns-${catalogName}-${roleName}-${ns}-${p}`,
+            "skipped",
+            "catalog creation failed"
+          )
+        }
+      }
+      for (const pr of roleConfig.assign_to ?? []) {
+        update(
+          `assign-cr-${catalogName}-${roleName}-to-${pr}`,
+          "skipped",
+          "catalog creation failed"
+        )
+      }
+    }
+    for (const ns of catalogConfig.namespaces ?? []) {
+      const nsName = typeof ns === "string" ? ns : ns.name
+      update(`ns-${catalogName}-${nsName}`, "skipped", "catalog creation failed")
+    }
+  }
+
+  try {
+    // 1. Create PrincipalRoles
+    const existingPrincipalRoles = new Set((await principalRolesApi.list()).map((r) => r.name))
+    for (const roleName of config.principal_roles ?? []) {
+      const id = `pr-${roleName}`
+      if (existingPrincipalRoles.has(roleName)) {
+        update(id, "skipped")
+        continue
+      }
+      await tryStep(id, () => principalRolesApi.create({ name: roleName }))
+    }
+
+    // 2. Create Principals
+    const existingPrincipals = new Set((await principalsApi.list()).map((p) => p.name))
+    for (const [principalName] of Object.entries(config.principals ?? {})) {
+      const id = `principal-${principalName}`
+      if (existingPrincipals.has(principalName)) {
+        update(id, "skipped")
+        continue
+      }
+      await tryStep(id, async () => {
+        const result = await principalsApi.create({ principal: { name: principalName } })
+        const clientId = result.credentials?.clientId ?? ""
+        const clientSecret = result.credentials?.clientSecret ?? ""
+        if (clientId && clientSecret) {
+          credentials.push({ principalName, clientId, clientSecret })
+        }
+      })
+    }
+
+    // 3. Create Catalogs + per-catalog entities
+    const existingCatalogs = new Set((await catalogsApi.list()).map((c) => c.name))
+    for (const catalogConfig of config.catalogs ?? []) {
+      const catalogName = catalogConfig.name
+
+      // 3a. Catalog
+      const catalogId = `catalog-${catalogName}`
+      update(catalogId, "running")
+      if (existingCatalogs.has(catalogName)) {
+        update(catalogId, "skipped")
+      } else {
+        try {
+          await catalogsApi.create({
+            catalog: {
+              name: catalogName,
+              type: catalogConfig.type ?? "INTERNAL",
+              properties: {
+                "default-base-location": normalizeLocation(
+                  catalogConfig.default_base_location,
+                  catalogConfig.storage_type
+                ),
+                ...catalogConfig.properties,
+              },
+              storageConfigInfo: buildStorageConfig(catalogConfig),
+            },
+          })
+          update(catalogId, "done")
+        } catch (e) {
+          update(
+            catalogId,
+            isConflict(e) ? "skipped" : "error",
+            isConflict(e) ? undefined : extractErrorMessage(e)
+          )
+          if (!isConflict(e)) {
+            // Catalog failed — mark all its sub-steps as skipped so they don't show as pending
+            skipCatalogSubSteps(catalogConfig)
+            continue
+          }
+        }
+      }
+
+      // 3b. Namespaces — must exist before namespace-scoped grants below
+      // Handle dot-notation paths (e.g. "parent.child")
+      for (const ns of catalogConfig.namespaces ?? []) {
+        const nsName = typeof ns === "string" ? ns : ns.name
+        const nsId = `ns-${catalogName}-${nsName}`
+        await tryStep(nsId, async () => {
+          const parts = nsName.split(".")
+          for (let i = 1; i < parts.length; i++) {
+            try {
+              await namespacesApi.create(catalogName, { namespace: parts.slice(0, i) })
+            } catch {
+              /* ignore */
+            }
+          }
+          await namespacesApi.create(catalogName, { namespace: parts })
+        })
+      }
+
+      // 3c. CatalogRoles + grants + assignments
+      const existingCatalogRoles = new Set(
+        (await catalogRolesApi.list(catalogName)).map((r) => r.name)
+      )
+      for (const [roleName, roleConfig] of Object.entries(catalogConfig.roles ?? {})) {
+        const roleId = `cr-${catalogName}-${roleName}`
+        update(roleId, "running")
+        if (!existingCatalogRoles.has(roleName)) {
+          try {
+            await catalogRolesApi.create(catalogName, { name: roleName })
+            update(roleId, "done")
+          } catch (e) {
+            update(
+              roleId,
+              isConflict(e) ? "skipped" : "error",
+              isConflict(e) ? undefined : extractErrorMessage(e)
+            )
+            if (!isConflict(e)) continue
+          }
+        } else {
+          update(roleId, "skipped")
+        }
+
+        for (const privilege of roleConfig.privileges?.catalog ?? []) {
+          const grantId = `grant-catalog-${catalogName}-${roleName}-${privilege}`
+          await tryStep(grantId, () =>
+            privilegesApi.grant(catalogName, roleName, {
+              type: "catalog",
+              privilege: privilege as CatalogPrivilege,
+            })
+          )
+        }
+
+        for (const [nsName, nsPrivileges] of Object.entries(
+          roleConfig.privileges?.namespace ?? {}
+        )) {
+          const nsParts = nsName.split(".")
+          for (const privilege of nsPrivileges) {
+            const grantId = `grant-ns-${catalogName}-${roleName}-${nsName}-${privilege}`
+            await tryStep(grantId, () =>
+              privilegesApi.grant(catalogName, roleName, {
+                type: "namespace",
+                namespace: nsParts,
+                privilege: privilege as NamespacePrivilege,
+              })
+            )
+          }
+        }
+
+        for (const principalRoleName of roleConfig.assign_to ?? []) {
+          const assignId = `assign-cr-${catalogName}-${roleName}-to-${principalRoleName}`
+          await tryStep(assignId, () =>
+            catalogRolesApi.grantToPrincipalRole(catalogName, roleName, principalRoleName)
+          )
+        }
+      }
+    }
+
+    // 4. Assign Principals → PrincipalRoles
+    for (const [principalName, principalConfig] of Object.entries(config.principals ?? {})) {
+      for (const roleName of principalConfig.roles ?? []) {
+        const id = `assign-p-${principalName}-to-${roleName}`
+        await tryStep(id, () => principalsApi.grantPrincipalRole(principalName, roleName))
+      }
+    }
+  } catch (e) {
+    // Fatal error (e.g. 403 Forbidden on list calls) — surface it on all unfinished steps
+    failRemaining(extractErrorMessage(e))
+  }
+
+  return { credentials }
+}
+
+export function buildSteps(config: SetupConfig): SetupStep[] {
+  const steps: SetupStep[] = []
+  const step = (id: string, label: string): SetupStep => ({ id, label, status: "pending" })
+
+  for (const roleName of config.principal_roles ?? []) {
+    steps.push(step(`pr-${roleName}`, `Create principal role: ${roleName}`))
+  }
+  for (const principalName of Object.keys(config.principals ?? {})) {
+    steps.push(step(`principal-${principalName}`, `Create principal: ${principalName}`))
+  }
+  for (const catalogConfig of config.catalogs ?? []) {
+    steps.push(step(`catalog-${catalogConfig.name}`, `Create catalog: ${catalogConfig.name}`))
+    for (const ns of catalogConfig.namespaces ?? []) {
+      const nsName = typeof ns === "string" ? ns : ns.name
+      steps.push(step(`ns-${catalogConfig.name}-${nsName}`, `Create namespace: ${nsName}`))
+    }
+    for (const [roleName, roleConfig] of Object.entries(catalogConfig.roles ?? {})) {
+      const cn = catalogConfig.name
+      steps.push(step(`cr-${cn}-${roleName}`, `Create catalog role: ${roleName}`))
+      for (const privilege of roleConfig.privileges?.catalog ?? []) {
+        steps.push(
+          step(`grant-catalog-${cn}-${roleName}-${privilege}`, `Grant ${privilege} to ${roleName}`)
+        )
+      }
+      for (const [nsName, nsPrivileges] of Object.entries(roleConfig.privileges?.namespace ?? {})) {
+        for (const privilege of nsPrivileges) {
+          steps.push(
+            step(
+              `grant-ns-${cn}-${roleName}-${nsName}-${privilege}`,
+              `Grant ${privilege} on ${nsName} to ${roleName}`
+            )
+          )
+        }
+      }
+      for (const principalRoleName of roleConfig.assign_to ?? []) {
+        steps.push(
+          step(
+            `assign-cr-${cn}-${roleName}-to-${principalRoleName}`,
+            `Assign ${roleName} → ${principalRoleName}`
+          )
+        )
+      }
+    }
+  }
+  for (const [principalName, principalConfig] of Object.entries(config.principals ?? {})) {
+    for (const roleName of principalConfig.roles ?? []) {
+      steps.push(
+        step(
+          `assign-p-${principalName}-to-${roleName}`,
+          `Assign principal role ${roleName} to ${principalName}`
+        )
+      )
+    }
+  }
+
+  return steps
+}
+
+/**
+ * For FILE storage, Polaris requires a file:// URI scheme in locations.
+ * Auto-prefix absolute paths that are missing the scheme.
+ */
+function normalizeLocation(location: string, storageType: string): string {
+  if (storageType.toLowerCase() === "file" && location.startsWith("/")) {
+    return `file://${location}`
+  }
+  return location
+}
+
+function buildStorageConfig(catalog: CatalogSetupConfig): StorageConfigInfo {
+  const storageTypeLower = catalog.storage_type.toLowerCase()
+  const storageType = catalog.storage_type.toUpperCase() as StorageConfigInfo["storageType"]
+  return {
+    storageType,
+    allowedLocations: (catalog.allowed_locations ?? [catalog.default_base_location]).map((l) =>
+      normalizeLocation(l, storageTypeLower)
+    ),
+    ...(storageTypeLower === "s3" && {
+      ...(catalog.role_arn && { roleArn: catalog.role_arn }),
+      ...(catalog.external_id && { externalId: catalog.external_id }),
+      ...(catalog.user_arn && { userArn: catalog.user_arn }),
+      ...(catalog.region && { region: catalog.region }),
+      ...(catalog.endpoint && { endpoint: catalog.endpoint }),
+      ...(catalog.sts_unavailable !== undefined && { stsUnavailable: catalog.sts_unavailable }),
+      ...(catalog.path_style_access !== undefined && {
+        pathStyleAccess: catalog.path_style_access,
+      }),
+    }),
+    ...(storageTypeLower === "azure" && {
+      ...(catalog.tenant_id && { tenantId: catalog.tenant_id }),
+      ...(catalog.multi_tenant_app_name && { multiTenantAppName: catalog.multi_tenant_app_name }),
+      ...(catalog.consent_url && { consentUrl: catalog.consent_url }),
+    }),
+    ...(storageTypeLower === "gcs" && {
+      ...(catalog.service_account && { gcsServiceAccount: catalog.service_account }),
+    }),
+  }
+}
+
+function extractErrorMessage(e: unknown): string {
+  if (e && typeof e === "object" && "response" in e) {
+    const { data, status } = (e as { response: { data?: unknown; status?: number } }).response ?? {}
+    if (
+      data &&
+      typeof data === "object" &&
+      typeof (data as Record<string, unknown>).message === "string"
+    )
+      return (data as { message: string }).message
+    if (status === 403) return "Permission denied (403 Forbidden)"
+    if (status) return `Server error ${status}`
+  }
+  return String(e)
+}
+
+function isConflict(e: unknown): boolean {
+  if (e && typeof e === "object" && "response" in e) {
+    return (e as { response?: { status?: number } }).response?.status === 409
+  }
+  return false
+}

--- a/console/src/lib/setup-presets.ts
+++ b/console/src/lib/setup-presets.ts
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { SetupConfig, CatalogSetupConfig } from "@/types/setup-config"
+
+export interface PresetParam {
+  key: string
+  label: string
+  placeholder: string
+  required: boolean
+}
+
+export interface Preset {
+  id: string
+  label: string
+  description: string
+  badge?: string
+  storageType: "file" | "s3" | "azure" | "gcs"
+  params: PresetParam[]
+  buildConfig: (params: Record<string, string>) => SetupConfig
+}
+
+const QUICKSTART_CONFIG: SetupConfig = {
+  principal_roles: ["quickstart_user_role"],
+  principals: { quickstart_user: { roles: ["quickstart_user_role"] } },
+  catalogs: [
+    {
+      name: "quickstart_catalog",
+      type: "INTERNAL",
+      storage_type: "file",
+      default_base_location: "file:///var/tmp/quickstart_catalog/",
+      allowed_locations: ["file:///var/tmp/quickstart_catalog/"],
+      roles: {
+        quickstart_catalog_role: {
+          assign_to: ["quickstart_user_role"],
+          privileges: { catalog: ["CATALOG_MANAGE_CONTENT"] },
+        },
+      },
+      namespaces: ["dev_namespace"],
+    },
+  ],
+}
+
+function buildQuickstartConfig(): SetupConfig {
+  return structuredClone(QUICKSTART_CONFIG)
+}
+
+function buildCloudConfig(
+  prefix: string,
+  storageConfig: Partial<CatalogSetupConfig>,
+  baseLocation: string
+): SetupConfig {
+  return {
+    principal_roles: [`${prefix}_admin_role`],
+    principals: { [`${prefix}_admin`]: { roles: [`${prefix}_admin_role`] } },
+    catalogs: [
+      {
+        name: `${prefix}_catalog`,
+        default_base_location: baseLocation,
+        allowed_locations: [baseLocation],
+        ...storageConfig,
+        roles: {
+          [`${prefix}_catalog_role`]: {
+            assign_to: [`${prefix}_admin_role`],
+            privileges: { catalog: ["CATALOG_MANAGE_CONTENT"] },
+          },
+        },
+        namespaces: ["default"],
+      } as CatalogSetupConfig,
+    ],
+  }
+}
+
+function buildS3Config(p: Record<string, string>): SetupConfig {
+  return buildCloudConfig(
+    "s3",
+    {
+      storage_type: "s3",
+      role_arn: p.roleArn,
+      region: p.region,
+      allowed_locations: [`s3://${p.bucket}/`],
+    },
+    `s3://${p.bucket}/polaris/`
+  )
+}
+
+function buildAzureConfig(p: Record<string, string>): SetupConfig {
+  const base = `abfss://${p.container}@${p.storageAccount}.dfs.core.windows.net/polaris/`
+  return buildCloudConfig("azure", { storage_type: "azure", tenant_id: p.tenantId }, base)
+}
+
+function buildGcsConfig(p: Record<string, string>): SetupConfig {
+  return buildCloudConfig(
+    "gcs",
+    { storage_type: "gcs", service_account: p.serviceAccount || undefined },
+    `gs://${p.bucket}/polaris/`
+  )
+}
+
+export const PRESETS: Preset[] = [
+  {
+    id: "quickstart",
+    label: "Quickstart",
+    description: "Local file storage. No cloud credentials needed. Perfect for trying Polaris.",
+    badge: "Recommended",
+    storageType: "file",
+    params: [],
+    buildConfig: buildQuickstartConfig,
+  },
+  {
+    id: "s3",
+    label: "AWS S3",
+    description: "Internal catalog backed by Amazon S3.",
+    storageType: "s3",
+    params: [
+      { key: "bucket", label: "S3 Bucket Name", placeholder: "my-polaris-bucket", required: true },
+      { key: "region", label: "AWS Region", placeholder: "us-east-1", required: true },
+      {
+        key: "roleArn",
+        label: "IAM Role ARN",
+        placeholder: "arn:aws:iam::123456789012:role/PolarisRole",
+        required: true,
+      },
+    ],
+    buildConfig: buildS3Config,
+  },
+  {
+    id: "azure",
+    label: "Azure ADLS Gen2",
+    description: "Internal catalog backed by Azure Data Lake Storage.",
+    storageType: "azure",
+    params: [
+      {
+        key: "storageAccount",
+        label: "Storage Account Name",
+        placeholder: "myaccount",
+        required: true,
+      },
+      { key: "container", label: "Container Name", placeholder: "polaris", required: true },
+      {
+        key: "tenantId",
+        label: "Azure Tenant ID",
+        placeholder: "12345678-1234-1234-1234-123456789abc",
+        required: true,
+      },
+    ],
+    buildConfig: buildAzureConfig,
+  },
+  {
+    id: "gcs",
+    label: "Google Cloud Storage",
+    description: "Internal catalog backed by Google Cloud Storage.",
+    storageType: "gcs",
+    params: [
+      { key: "bucket", label: "GCS Bucket Name", placeholder: "my-polaris-bucket", required: true },
+      {
+        key: "serviceAccount",
+        label: "Service Account Email (optional)",
+        placeholder: "polaris@project.iam.gserviceaccount.com",
+        required: false,
+      },
+    ],
+    buildConfig: buildGcsConfig,
+  },
+]

--- a/console/src/pages/Home.tsx
+++ b/console/src/pages/Home.tsx
@@ -17,13 +17,18 @@
  * under the License.
  */
 
+import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { catalogsApi } from "@/api/management/catalogs"
 import { principalsApi } from "@/api/management/principals"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Sparkles } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Sparkles, Wand2 } from "lucide-react"
+import { QuickSetupWizard } from "@/components/forms/QuickSetupWizard"
 
 export function Home() {
+  const [isWizardOpen, setIsWizardOpen] = useState(false)
+
   const { data: catalogs } = useQuery({
     queryKey: ["catalogs"],
     queryFn: () => catalogsApi.list(),
@@ -61,6 +66,28 @@ export function Home() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Quick Setup Card */}
+      <Card className="border-primary/30 bg-primary/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Wand2 className="h-5 w-5 text-primary" />
+            Quick Setup
+          </CardTitle>
+          <CardDescription>
+            Bootstrap a working Polaris environment in seconds — creates a catalog, principal,
+            roles, namespace, and privilege grants.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={() => setIsWizardOpen(true)}>
+            <Wand2 className="mr-2 h-4 w-4" />
+            Run Quick Setup
+          </Button>
+        </CardContent>
+      </Card>
+
+      <QuickSetupWizard open={isWizardOpen} onOpenChange={setIsWizardOpen} />
 
       {/* Quick Stats */}
       <div className="grid grid-cols-3 gap-4">

--- a/console/src/types/setup-config.ts
+++ b/console/src/types/setup-config.ts
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface SetupConfig {
+  principal_roles?: string[]
+  principals?: Record<string, PrincipalConfig>
+  catalogs?: CatalogSetupConfig[]
+}
+
+export interface PrincipalConfig {
+  type?: "SERVICE" | "USER"
+  roles?: string[]
+  properties?: Record<string, string>
+}
+
+export interface CatalogSetupConfig {
+  name: string
+  type?: "INTERNAL" | "EXTERNAL"
+  storage_type: "file" | "s3" | "azure" | "gcs"
+  default_base_location: string
+  allowed_locations?: string[]
+  // S3-specific (top-level in YAML)
+  role_arn?: string
+  external_id?: string
+  user_arn?: string
+  region?: string
+  endpoint?: string
+  sts_unavailable?: boolean
+  path_style_access?: boolean
+  // Azure-specific (top-level in YAML)
+  tenant_id?: string
+  multi_tenant_app_name?: string
+  consent_url?: string
+  // GCS-specific (top-level in YAML)
+  service_account?: string
+  // General
+  properties?: Record<string, string>
+  roles?: Record<string, CatalogRoleSetupConfig>
+  namespaces?: (string | NamespaceSetupConfig)[]
+  policies?: Record<string, unknown>
+}
+
+export interface CatalogRoleSetupConfig {
+  assign_to?: string[]
+  privileges?: {
+    catalog?: string[]
+    namespace?: Record<string, string[]>
+  }
+}
+
+export interface NamespaceSetupConfig {
+  name: string
+  children?: string[]
+  properties?: Record<string, string>
+}


### PR DESCRIPTION
Adds an interactive wizard to the console that lets users bootstrap Polaris from scratch — creating principal roles, principals, catalogs, namespaces, and catalog roles in one guided flow using either preset examples or user-provided YAML.

## Features & Changes

 - Two setup modes — choose a ready-made preset (Local File, AWS S3, Azure ADLS, Google Cloud) or paste/upload a custom YAML config in the same format as `polaris setup apply`
 - Guided preset flow — parameterized inputs (catalog name, storage location, role ARN, etc.) with required-field validation before proceeding
 - YAML mode with live validation — 300ms debounce parse with inline feedback; validates structure, required fields (storage_type, default_base_location), and storage type values
 - Step preview — review all planned actions before applying; existing entities are automatically skipped (409 treated as success)
 - Live progress view — each step updates in real-time as it executes; failed steps are clearly flagged while remaining steps continue where possible
 - Credential display — generated principal credentials are shown with copy buttons at the end of the flow; not persisted anywhere
 - Error resilience — catalog sub-steps are skipped gracefully if catalog creation fails; a fatal API error (e.g. 403 on list) halts remaining steps cleanly with a summary

## Limitations / Known Issues

 - No partial resume — if the wizard is closed mid-execution, there is no way to resume; re-running from the start is safe (idempotent) but will skip already-created entities
 - YAML validation is structural only — the wizard validates shape and required fields but does not verify that referenced roles, catalogs, or principals actually exist in Polaris before running
 - Preset YAML view is read-only — the generated config from a preset cannot be edited in the wizard before applying; switch to YAML mode for full control
 - Credentials shown once — generated client secrets are displayed only in the final step and are not recoverable after closing the wizard
 - No teardown support — the wizard only creates entities; there is no corresponding flow to delete or clean up the resources it provisioned

https://github.com/user-attachments/assets/299cc61b-d326-42fb-8780-64253930875c


