### PR TITLE
feat(console/helm): add gatewayGroup and gatewayKind to HTTPRoute

### DIFF
--- a/console/helm/templates/httproute.yaml
+++ b/console/helm/templates/httproute.yaml
@@ -34,6 +34,8 @@ spec:
   hostnames: {{ .Values.httproute.hosts }}
   parentRefs:
     - name: {{ .Values.httproute.gatewayName}}
+      group: {{ .Values.httproute.gatewayGroup }}
+      kind: {{ .Values.httproute.gatewayKind }}
       namespace: {{ .Values.httproute.gatewayNamespace }}
       {{- if .Values.httproute.sectionName }}
       sectionName: {{ .Values.httproute.sectionName }}

--- a/console/helm/values.yaml
+++ b/console/helm/values.yaml
@@ -62,6 +62,8 @@ httproute:
   enabled: false
   annotations: {}
   port: 80
+  gatewayGroup: gateway.networking.k8s.io
+  gatewayKind: Gateway
   # Name of the httpGateway deployment
   gatewayName: ""
   # Namespace where the httpGateway is deployed


### PR DESCRIPTION
The goal of this PR is to add `group` and `kind` fields to the HTTPRoute `parentRefs` entry, defaulting to `gateway.networking.k8s.io` and `Gateway` respectively. 

This allows explicit configuration of the parent gateway resource type instead of relying on implicit defaults.

I have deployed the polaris-console with the helm chart and with argocd, and the httpRoute is always at the status OutOfSync due to the fact the fields `spec.parentRefs.group` and `spec.parentRefs.kind` are not set.

<img width="1833" height="825" alt="image" src="https://github.com/user-attachments/assets/c400e797-ec9d-40e8-a06b-cab788266f9d" />


