### PR TITLE
Make target port configurable for console

### DIFF
--- a/console/helm/templates/deployment.yaml
+++ b/console/helm/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - containerPort: 80
+            - port: {{ .Values.service.targetPort | default 80 }}
           env:
             - name: VITE_POLARIS_API_URL
               value: {{ .Values.env.polarisApiUrl | quote }}
@@ -55,14 +55,14 @@ spec:
           readinessProbe:
             httpGet:
               path: /health
-              port: 80
+              port: {{ .Values.service.targetPort | default 80 }}
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /health
-              port: 80
+              port: {{ .Values.service.targetPort | default 80 }}
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 5

--- a/console/helm/templates/ingress.yaml
+++ b/console/helm/templates/ingress.yaml
@@ -56,7 +56,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
           {{- end }}
     {{- end }}
 

--- a/console/helm/templates/service.yaml
+++ b/console/helm/templates/service.yaml
@@ -27,7 +27,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 80
+      targetPort: {{ .Values.service.targetPort | default 80 }}
       protocol: TCP
   selector:
     app: {{ include "polaris-console.fullname" . }}

--- a/console/helm/values.yaml
+++ b/console/helm/values.yaml
@@ -28,6 +28,7 @@ replicaCount: 1
 service:
   type: ClusterIP
   port: 80
+  targetPort: 80
 
 env:
   polarisApiUrl: "http://polaris:8181"


### PR DESCRIPTION
This PR fixes https://github.com/apache/polaris-tools/issues/218. Also, it fixes a helm chart bug in ingress where `Values.service.port` was not accessible as it was within the `range` loop.