### PR TITLE
Add overwrite support for migrator

### DIFF
--- a/iceberg-catalog-migrator/.gitignore
+++ b/iceberg-catalog-migrator/.gitignore
@@ -17,6 +17,69 @@
 # under the License.
 #
 
+# Ignore Gradle GUI config
+gradle-app.setting
+
 # Ignore Gradle wrapper jar file
 gradle/wrapper/gradle-wrapper.jar
 gradle/wrapper/gradle-wrapper-*.sha256
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+.env
+
+# IntelliJ
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Gradle
+/.gradle
+/build-logic/.gradle
+/build-logic/.kotlin
+**/build/
+!src/**/build/
+
+# jenv
+.java-version
+
+# binary files
+*.class
+*.jar
+*.zip
+*.tar.gz
+*.tgz
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# macOS
+*.DS_Store
+
+# vscode
+.vscode/
+
+# Python Virtual Env
+.venv
+venv
+
+# AI / Agentic Development Tools
+.agents/
+.aider/
+.aider.chat.history.md
+.aider.input.history
+.codex/
+.claude/
+.cursor/
+.opencode/
+skills-lock.json

--- a/iceberg-catalog-migrator/api/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/CatalogMigrator.java
+++ b/iceberg-catalog-migrator/api/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/CatalogMigrator.java
@@ -53,6 +53,15 @@ public abstract class CatalogMigrator {
   /** Delete the table entries from the source catalog after successful registration. */
   public abstract boolean deleteEntriesFromSourceCatalog();
 
+  /**
+   * Re-register the table in the target catalog if its metadata location has diverged from source.
+   * *
+   */
+  @Value.Default
+  public boolean overwrite() {
+    return false;
+  }
+
   /** Enable the stacktrace in logs in case of failures. */
   @Value.Default
   public boolean enableStacktrace() {
@@ -211,11 +220,42 @@ public abstract class CatalogMigrator {
   private boolean registerTableToTargetCatalog(TableIdentifier tableIdentifier) {
     try {
       createNamespacesIfNotExistOnTargetCatalog(tableIdentifier.namespace());
-      // register the table to the target catalog
-      TableOperations ops = ((BaseTable) sourceCatalog().loadTable(tableIdentifier)).operations();
-      targetCatalog().registerTable(tableIdentifier, ops.current().metadataFileLocation());
-      LOG.info("Successfully registered the table {}", tableIdentifier);
-      return true;
+
+      TableOperations sourceOps =
+          ((BaseTable) sourceCatalog().loadTable(tableIdentifier)).operations();
+      String sourceMetadataLocation = sourceOps.current().metadataFileLocation();
+
+      try {
+        targetCatalog().registerTable(tableIdentifier, sourceMetadataLocation);
+        LOG.info("Successfully registered the table {}", tableIdentifier);
+        return true;
+      } catch (AlreadyExistsException ex) {
+        if (overwrite()) {
+          TableOperations targetOps =
+              ((BaseTable) targetCatalog().loadTable(tableIdentifier)).operations();
+          String targetMetadataLocation = targetOps.current().metadataFileLocation();
+
+          if (sourceMetadataLocation.equals(targetMetadataLocation)) {
+            LOG.info(
+                "Table {} is already in sync with the target catalog. Skipping re-registration.",
+                tableIdentifier);
+            return true;
+          }
+
+          LOG.info(
+              "Table {} metadata location has changed. Dropping and re-registering it in the target catalog as overwrite is enabled.",
+              tableIdentifier);
+          targetCatalog().dropTable(tableIdentifier, false);
+          targetCatalog().registerTable(tableIdentifier, sourceMetadataLocation);
+          LOG.info("Successfully overwritten the table {}", tableIdentifier);
+          return true;
+        } else {
+          LOG.error(
+              "Table {} already exists in the target catalog. Use --overwrite to re-register it.",
+              tableIdentifier);
+          return false;
+        }
+      }
     } catch (Exception ex) {
       if (enableStacktrace()) {
         LOG.error("Unable to register the table {}", tableIdentifier, ex);

--- a/iceberg-catalog-migrator/api/src/test/java/org/apache/polaris/iceberg/catalog/migrator/api/AbstractTestCatalogMigrator.java
+++ b/iceberg-catalog-migrator/api/src/test/java/org/apache/polaris/iceberg/catalog/migrator/api/AbstractTestCatalogMigrator.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 import nl.altindag.log.LogCaptor;
 import nl.altindag.log.model.LogEvent;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -32,6 +33,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -197,6 +199,36 @@ public abstract class AbstractTestCatalogMigrator extends AbstractTest {
     Assertions.assertThat(result.registeredTableIdentifiers()).isEmpty();
     Assertions.assertThat(result.failedToRegisterTableIdentifiers()).contains(FOO_TBL2);
     Assertions.assertThat(result.failedToDeleteTableIdentifiers()).isEmpty();
+  }
+
+  @Test
+  public void testRegisterWithOverwrite() {
+    // register foo.tbl1
+    catalogMigratorWithDefaultArgs(false).registerTable(FOO_TBL1);
+    // update property to trigger a commit
+    sourceCatalog.loadTable(FOO_TBL1).updateProperties().set("sync-test", "v1").commit();
+    // register again without overwrite option to trigger error
+    CatalogMigrationResult result =
+        catalogMigratorWithDefaultArgs(false).registerTable(FOO_TBL1).result();
+    Assertions.assertThat(result.registeredTableIdentifiers()).isEmpty();
+    Assertions.assertThat(result.failedToRegisterTableIdentifiers()).containsExactly(FOO_TBL1);
+
+    // register again with overwrite
+    result =
+        ImmutableCatalogMigrator.builder()
+            .sourceCatalog(sourceCatalog)
+            .targetCatalog(targetCatalog)
+            .deleteEntriesFromSourceCatalog(false)
+            .overwrite(true)
+            .build()
+            .registerTable(FOO_TBL1)
+            .result();
+    Assertions.assertThat(result.registeredTableIdentifiers()).containsExactly(FOO_TBL1);
+    Assertions.assertThat(result.failedToRegisterTableIdentifiers()).isEmpty();
+
+    // verify target catalog has the updated metadata
+    Table targetTable = targetCatalog.loadTable(FOO_TBL1);
+    Assertions.assertThat(targetTable.properties().get("sync-test")).isEqualTo("v1");
   }
 
   @ParameterizedTest

--- a/iceberg-catalog-migrator/build.gradle.kts
+++ b/iceberg-catalog-migrator/build.gradle.kts
@@ -76,6 +76,9 @@ tasks.named<RatTask>("rat").configure {
 
   // Rat can't scan binary images
   excludes.add("**/*.png")
+
+  // Misc build artifacts
+  excludes.add(".java-version")
 }
 
 // Pass environment variables:

--- a/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/BaseRegisterCommand.java
+++ b/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/BaseRegisterCommand.java
@@ -75,6 +75,14 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
   private boolean isDryRun;
 
   @CommandLine.Option(
+      names = {"--overwrite"},
+      description =
+          "Optional configuration to drop (without deleting data) and re-register a table in the target catalog if its "
+              + "metadata location has diverged from the source. Table already in sync are left unchanged. Without this "
+              + "option, registration fails if the table already exists in the target catalog.")
+  private boolean overwrite;
+
+  @CommandLine.Option(
       names = {"--disable-safety-prompts"},
       description = "Optional configuration to disable safety prompts which needs console input.")
   private boolean disablePrompts;
@@ -95,7 +103,7 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
   public BaseRegisterCommand() {}
 
   protected abstract CatalogMigrator catalogMigrator(
-      Catalog sourceCatalog, Catalog targetCatalog, boolean enableStackTrace);
+      Catalog sourceCatalog, Catalog targetCatalog, boolean overwrite, boolean enableStackTrace);
 
   protected abstract boolean canProceed(Catalog sourceCatalog);
 
@@ -132,7 +140,7 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
       }
 
       CatalogMigrator catalogMigrator =
-          catalogMigrator(sourceCatalog, targetCatalog, enableStackTrace);
+          catalogMigrator(sourceCatalog, targetCatalog, overwrite, enableStackTrace);
 
       if (identifiers.isEmpty()) {
         consoleLog.info("Identifying tables for {} ...", operation());

--- a/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/MigrateCommand.java
+++ b/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/MigrateCommand.java
@@ -45,12 +45,13 @@ public class MigrateCommand extends BaseRegisterCommand {
 
   @Override
   protected CatalogMigrator catalogMigrator(
-      Catalog sourceCatalog, Catalog targetCatalog, boolean enableStackTrace) {
+      Catalog sourceCatalog, Catalog targetCatalog, boolean overwrite, boolean enableStackTrace) {
 
     return ImmutableCatalogMigrator.builder()
         .sourceCatalog(sourceCatalog)
         .targetCatalog(targetCatalog)
         .deleteEntriesFromSourceCatalog(true)
+        .overwrite(overwrite)
         .enableStacktrace(enableStackTrace)
         .build();
   }

--- a/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/RegisterCommand.java
+++ b/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/RegisterCommand.java
@@ -42,11 +42,12 @@ public class RegisterCommand extends BaseRegisterCommand {
 
   @Override
   protected CatalogMigrator catalogMigrator(
-      Catalog sourceCatalog, Catalog targetCatalog, boolean enableStackTrace) {
+      Catalog sourceCatalog, Catalog targetCatalog, boolean overwrite, boolean enableStackTrace) {
     return ImmutableCatalogMigrator.builder()
         .sourceCatalog(sourceCatalog)
         .targetCatalog(targetCatalog)
         .deleteEntriesFromSourceCatalog(false)
+        .overwrite(overwrite)
         .enableStacktrace(enableStackTrace)
         .build();
   }

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/CLIOptionsTest.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/CLIOptionsTest.java
@@ -251,6 +251,30 @@ public class CLIOptionsTest {
     Assertions.assertThat(run.getOut()).startsWith(System.getProperty("expectedCLIVersion"));
   }
 
+  @Test
+  public void testOverwriteOption() throws Exception {
+    List<String> catalogArgs =
+        Lists.newArrayList(
+            "--source-catalog-type",
+            "HADOOP",
+            "--source-catalog-properties",
+            "warehouse=/tmp/source",
+            "--target-catalog-type",
+            "HADOOP",
+            "--target-catalog-properties",
+            "warehouse=/tmp/target",
+            "--overwrite",
+            "--dry-run");
+    for (String command : Lists.newArrayList("register", "migrate")) {
+      List<String> args = Lists.newArrayList(command);
+      args.addAll(catalogArgs);
+      RunCLI run = RunCLI.run(args);
+      Assertions.assertThat(run.getErr())
+          .as("--overwrite should be recognized for '%s'", command)
+          .doesNotContain("Unmatched argument");
+    }
+  }
+
   private static void executeAndValidateResults(
       String command, List<String> args, String expectedMessage, int expectedErrorCode)
       throws Exception {

--- a/iceberg-catalog-migrator/docs/examples.md
+++ b/iceberg-catalog-migrator/docs/examples.md
@@ -120,3 +120,14 @@ java -jar iceberg-catalog-migrator-cli-0.0.1.jar migrate \
 
 ## Tips
 1. Before migrating tables to Polaris, make sure the catalog is configured to the `base-location` same as source catalog `warehouse` location during catalog creation.
+2. If you have already registered tables and the source catalog metadata has changed (e.g., after table maintenance or new commits), you can use the `--overwrite`
+flags to update the target catalog metadata pointers without having to manually drop and target tables first.
+    ```shell
+    java -jar iceberg-catalog-migrator-cli-0.0.1.jar migrate \
+    --source-catalog-type REST  \
+    --source-catalog-properties uri=http://localhost:60904/api/catalog,warehouse=test,token=$TOKEN \
+    --target-catalog-type GLUE \
+    --target-catalog-properties warehouse=s3a://some-bucket/wh/,io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --overwrite
+    ```
+    This command is idempotent: it will only perform a re-registration if the metadata location has actually changed.


### PR DESCRIPTION
Currently the migrator supports both `register` and `migrate` which are great. However, for use cases where people would register the tables and let them sit idle for couple of days then data ops kicked in on the source catalog which removed the previous metadata pointers, this can caused the target tables to be not read-able as it would fails when looking up metadata file from metadata pointer.

To overcome this issue, I added `--overwrite` option which would re-register a table if and only if the metadata pointer changed.