### PR TITLE
SECURITY.md: link the project's threat model for agent discoverability

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,3 +22,12 @@
 Apache Polaris follows the process from [ASF security team](https://www.apache.org/security/).
 
 Please report any security issues to [security@apache.org](mailto:security@apache.org).
+
+## Threat Model
+
+The Polaris Tools project maintains a threat model in
+[SECURITY-THREAT-MODEL.md](./SECURITY-THREAT-MODEL.md). It documents
+per-tool security boundaries, in-scope vs. out-of-scope issues, trust
+assumptions, security invariants, and triage guidance — useful both
+for human reviewers handling reports and for automated security
+tooling that consults the model before scanning.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

## What this PR does

Adds a `Threat Model` section to `SECURITY.md` pointing at the existing `SECURITY-THREAT-MODEL.md` so the conventional `AGENTS.md → SECURITY.md → model` chain is mechanically complete.

No other files touched; no change to the threat-model content itself.

## Why

The threat model is already discoverable via `AGENTS.md`'s "Understand The Tool First" / "Security Issues" sections, which link directly to `SECURITY-THREAT-MODEL.md`. That works fine for an automated agentic security scan the ASF Security team is piloting — the agent finds the model by reading `AGENTS.md`.

The reason for adding the same link from `SECURITY.md` is the **GitHub UI affordance**: the "Report a vulnerability" button surfaces the contents of `SECURITY.md` at the repo root. External security researchers (not just automated agents) land there first when they decide to report something. Right now they see only the generic ASF-process boilerplate; with this change they also see a pointer to the project's threat model, which clarifies the per-tool scope before they invest time in a report.

## What this PR does NOT do

- It does **not** change the threat model itself. `SECURITY-THREAT-MODEL.md` (introduced in `apache/polaris-tools#228`) stays the source of truth.
- It does **not** introduce a new reporting alias. Reports continue to flow through `security@apache.org`.
- It does **not** alter the `AGENTS.md` discoverability chain, which already works.

Questions / pushback welcome. Happy to adjust wording or move the section if the project has a house style.
