### PR TITLE
Fix deployment port

### DIFF
--- a/console/helm/templates/deployment.yaml
+++ b/console/helm/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - port: {{ .Values.service.targetPort | default 80 }}
+            - containerPort: {{ .Values.service.targetPort | default 80 }}
           env:
             - name: VITE_POLARIS_API_URL
               value: {{ .Values.env.polarisApiUrl | quote }}


### PR DESCRIPTION
Appears to be breaking changes introduced by me last time: https://github.com/apache/polaris-tools/commit/1a452e73a8deae491a8da6be5da608e2df35e0ef

The current main should fail with following during install:
```
➜  console git:(main) helm install polaris-console ./helm -n polaris
Error: INSTALLATION FAILED: server-side apply failed for object polaris/polaris-console apps/v1, Kind=Deployment: failed to create typed patch object (polaris/polaris-console; apps/v1, Kind=Deployment): .spec.template.spec.containers[name="polaris-console"].ports[containerPort=0,protocol="TCP"].port: field not declared in schema
```