### PR TITLE
Console: Change console to use non-80 default port

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -240,7 +240,7 @@ make build-docker
 Then, you run Polaris Console using:
 
 ```bash
-docker run -p 8080:80 \
+docker run -p 4000:4000 \
   -e VITE_POLARIS_API_URL=http://polaris:8181 \
   -e VITE_POLARIS_REALM=POLARIS \
   -e VITE_POLARIS_PRINCIPAL_SCOPE=PRINCIPAL_ROLE:ALL \
@@ -250,7 +250,7 @@ docker run -p 8080:80 \
 To enable OIDC authentication, add OIDC environment variables:
 
 ```bash
-docker run -p 8080:80 \
+docker run -p 4000:4000 \
   -e VITE_POLARIS_API_URL=http://polaris:8181 \
   -e VITE_POLARIS_REALM=POLARIS \
   -e VITE_POLARIS_PRINCIPAL_SCOPE=PRINCIPAL_ROLE:ALL \
@@ -288,7 +288,7 @@ and start Polaris instance in `polaris` namespace via helm.
 
 4. **Access the console:**
    ```bash
-   kubectl port-forward svc/polaris-console 4000:80 -n polaris
+   kubectl port-forward svc/polaris-console 4000:4000 -n polaris
    ```
    Open http://localhost:4000 in your browser.
 
@@ -310,7 +310,7 @@ env:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 4000
 
 replicaCount: 1
 ```

--- a/console/docker/Dockerfile
+++ b/console/docker/Dockerfile
@@ -58,8 +58,8 @@ COPY --chown=10000:10001 --chmod=744 docker/generate-config.sh /generate-config.
 COPY --from=builder /app/dist /opt/app-root/src
 
 RUN chown -R polaris:polaris /opt/app-root
-# Expose port 80
-EXPOSE 80
+# Expose port 4040
+EXPOSE 4040
 RUN chown -R polaris:polaris /var/log/nginx \
     && chown -R polaris:polaris /etc/nginx/conf.d \
     && chown -R polaris:polaris /var/lib/nginx \
@@ -68,4 +68,3 @@ RUN chown -R polaris:polaris /var/log/nginx \
 USER polaris
 # Use the script as entrypoint to generate config.js from env vars at startup
 ENTRYPOINT ["/generate-config.sh"]
-

--- a/console/docker/nginx.conf
+++ b/console/docker/nginx.conf
@@ -16,7 +16,7 @@
 # under the License.
 
 server {
-    listen 80;
+    listen 4000;
     server_name localhost;
     root /opt/app-root/src;
     index index.html;
@@ -57,4 +57,3 @@ server {
         add_header Content-Type text/plain;
     }
 }
-

--- a/console/helm/values.yaml
+++ b/console/helm/values.yaml
@@ -27,8 +27,8 @@ replicaCount: 1
 
 service:
   type: ClusterIP
-  port: 80
-  targetPort: 80
+  port: 4000
+  targetPort: 4000
 
 env:
   polarisApiUrl: "http://polaris:8181"


### PR DESCRIPTION
We may want some discussions around this before merge. Currently we are using port `80` on nginx for port binding and this can be problematic as it is a privilege port and can cause issues such as https://github.com/apache/polaris-tools/issues/231.

Generally, I would change port `80` to `8080` instead. However, from our example, we also using keycloak on localhost and that is using `8080` as well. It may be confusing if we are using `8080` as well (or we should just update doc to map keycloak to other port?  