### PR TITLE
Console: Update dockerfile images

### DIFF
--- a/console/docker/Dockerfile
+++ b/console/docker/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 # Build stage
-FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.7-1767673763 AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:1-1779828907 AS builder
 
 # Default environment variables (can be overridden at runtime)
 ENV VITE_POLARIS_API_URL=http://polaris:8181
@@ -42,7 +42,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM registry.access.redhat.com/ubi9/nginx-126:9.7-1767846422
+FROM registry.access.redhat.com/ubi9/nginx-126:1-1779858291
 USER root
 RUN groupadd --gid 10001 polaris && \
     useradd --uid 10000 --gid polaris polaris


### PR DESCRIPTION
We switched to RHEL ubi9 images via https://github.com/apache/polaris-tools/pull/129, I noticed both images in this dockerfile hasn't been update for the last 4 months or so. Then for anyone who is trying to use polaris console image, this is not useable as the image itself is full of CVEs.

Based on my understanding, the reason on why this was not getting update via renovate bot is due to the image alias that we are using. For RHEL ubi images, they are using `1-EPOCH` (the tag alias we are using is also valid), but looking at the RHEL endpoint, I am not seeing the alias:
```
➜  ~ curl -s "https://registry.access.redhat.com/v2/ubi9/nodejs-22-minimal/tags/list"
{"name":"redhat-prod/ubi9----nodejs-22-minimal","tags":["1","1-1730522596","1-1730522596-source","1-1731671211","1-1731671211-source","1-1732617876","1-1732617876-source","1-1734513095","1-1734513095-source","1-1736425083","1-1736425083-source","1-1736731764","1-1736731764-source","1-1737531032","1-1737531032-source","1-1737562536","1-1737562536-source","1-1737619681","1-1737619681-source","1-1737939980","1-1737939980-source","1-1738661183","1-1738661183-source","1-1738870241","1-1738870241-source","1-1739407042","1-1739407042-source","1-1739448964","1-1739448964-source","1-1740411730","1-1740411730-source","1-1740651938","1-1740651938-source","1-1741091630","1-1741091630-source","1-1741243183","1-1741243183-source","1-1741873206","1-1741873206-source","1-1742929466","1-1742929466-source","1-1745513547","1-1745513547-source","1-1746006420","1-1746006420-source","1-1746535384","1-1746535384-source","1-1747315151","1-1747315151-source","1-1749013782","1-1749013782-source","1-1749542063","1-1749542063-source","1-1750840220","1-1750840220-source","1-1751380832","1-1751380832-source","1-1752501970","1-1752501970-source","1-1753796458","1-1753796458-source","1-1754272205","1-1754272205-source","1-1754381159","1-1754381159-source","1-1754479264","1-1754479264-source","1-1754870984","1-1754870984-source","1-1755749564","1-1755749564-source","1-1758213587","1-1758213587-source","1-1759106173","1-1759106173-source","1-1760544659","1-1760544659-source","1-1762215467","1-1762215467-source","1-1763041361","1-1763041361-source","1-1763382208","1-1763382208-source","1-1764607007","1-1764607007-source","1-1764822684","1-1764822684-source","1-1766364286","1-1766364286-source","1-1767673763","1-1767673763-source","1-1769430243","1-1769430243-source","1-1770222338","1-1770222338-source","1-1770309067","1-1770309067-source","1-1771388883","1-1771388883-source","1-1773232371"]}
```

Thus, it may be due to it is tracking `1-EPOCH` version which we will never get a image version bump in this case (polaris ubi images is using `1-EPOCH` as well). 