### PR TITLE
Added security context to console deployment

### DIFF
--- a/console/helm/templates/deployment.yaml
+++ b/console/helm/templates/deployment.yaml
@@ -37,8 +37,12 @@ spec:
       {{- if .Values.image.pullSecrets }}
       {{- toYaml .Values.image.pullSecrets | nindent 6 }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: polaris-console
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/console/helm/values.yaml
+++ b/console/helm/values.yaml
@@ -43,6 +43,13 @@ resources:
     cpu: 250m
     memory: 256Mi
 
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: 
+  runAsUser: 10000
+  runAsGroup: 10001
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
We've run into issues running the console due to our cluster admins enforcing a default security context that misaligns with the console pod. Adding the security context block(s) will allow us to set the correct user/group security context to have it work. 