### PR TITLE
Console: Fix console CI

### DIFF
--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["20.19", "22.12"]
+        node-version: ["20.19", "22.13"]
 
     steps:
       - name: Checkout Polaris Tools project

--- a/console/README.md
+++ b/console/README.md
@@ -24,7 +24,7 @@ A modern web interface for Apache Polaris, built with React, TypeScript, TanStac
 ## Getting Started
 
 ### Prerequisites
-- Node.js 20.19+ (or 22.12+) and npm (or yarn)
+- Node.js 20.19+ (or 22.13+) and npm (or yarn)
 
 ### Installation
 

--- a/console/src/hooks/useSearchData.ts
+++ b/console/src/hooks/useSearchData.ts
@@ -108,13 +108,11 @@ export function useSearchData(enabled: boolean): SearchData {
       const results = await Promise.allSettled(
         allNamespacePairs.map(async ({ catalog, namespace }) => {
           const tables = await tablesApi.list(catalog, namespace)
-          return tables.map(
-            (t): ObjectEntry => ({
-              catalog,
-              namespace: t.namespace || namespace,
-              name: t.name,
-            })
-          )
+          return tables.map((t): ObjectEntry => ({
+            catalog,
+            namespace: t.namespace || namespace,
+            name: t.name,
+          }))
         })
       )
       return results
@@ -131,13 +129,11 @@ export function useSearchData(enabled: boolean): SearchData {
       const results = await Promise.allSettled(
         allNamespacePairs.map(async ({ catalog, namespace }) => {
           const views = await viewsApi.list(catalog, namespace)
-          return views.map(
-            (v): ObjectEntry => ({
-              catalog,
-              namespace: v.namespace || namespace,
-              name: v.name,
-            })
-          )
+          return views.map((v): ObjectEntry => ({
+            catalog,
+            namespace: v.namespace || namespace,
+            name: v.name,
+          }))
         })
       )
       return results


### PR DESCRIPTION
Bump nodejs version from 22.12 to 22.13 due to https://github.com/eslint/js/pull/696 from [eslint-visitor-keys](https://github.com/eslint/js/releases/tag/eslint-visitor-keys-v5.0.0)