### PR TITLE
Console: Fix console renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,7 @@
     // Update all dockerfiles
     "ignorePaths": [],
     // UBI images use timestamp-based versions; allow large increments
-    "maxMajorIncrement": 99999999,
+    "maxMajorIncrement": 9999999999,
   },
 
   packageRules: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,13 @@
     ":dependencyDashboard",
   ],
 
+  dockerfile: {
+    // Update all dockerfiles
+    "ignorePaths": [],
+    // UBI images use timestamp-based versions; allow large increments
+    "maxMajorIncrement": 99999999,
+  },
+
   packageRules: [
     // Check for updates, do not merge automatically. This rule does effectively nothing, but serves as a
     // reference for the kinds of managers used in Polaris.


### PR DESCRIPTION
Fix for https://github.com/apache/polaris-tools/issues/246 where renovate bot is not able to bump the docker image version due to high version diff.

Current:
```
➜  polaris-tools git:(fix_console_docker_renovte) ✗ LOG_LEVEL=debug renovate --platform=local --repository-cache=reset | grep 'Skipping registry'
DEBUG: Skipping registry.access.redhat.com/ubi9/nodejs-22-minimal@1779828950 because major increment 1779828949 exceeds maxMajorIncrement 500 (repository=local)
DEBUG: Skipping registry.access.redhat.com/ubi9/nodejs-22-minimal@1781566560 because major increment 1781566559 exceeds maxMajorIncrement 500 (repository=local)
DEBUG: Skipping registry.access.redhat.com/ubi9/nodejs-22-minimal@1782235262 because major increment 1782235261 exceeds maxMajorIncrement 500 (repository=local)
DEBUG: Skipping registry.access.redhat.com/ubi9/nodejs-22-minimal@1782409376 because major increment 1782409375 exceeds maxMajorIncrement 500 (repository=local)
DEBUG: Skipping registry.access.redhat.com/ubi9/nodejs-22-minimal@1782736050 because major increment 1782736049 exceeds maxMajorIncrement 500 (repository=local)
DEBUG: Skipping registry.access.redhat.com/ubi9/nodejs-22-minimal@1782826652 because major increment 1782826651 exceeds maxMajorIncrement 500 (repository=local)
DEBUG: Skipping registry.access.redhat.com/ubi9/nginx-126@1779858339 because major increment 1779858338 exceeds maxMajorIncrement 500 (repository=local)
...
```

With this fix:
```
➜  polaris-tools git:(fix_console_docker_renovte) ✗ LOG_LEVEL=debug renovate --platform=local --repository-cache=reset | grep 'Skipping registry'
➜  polaris-tools git:(fix_console_docker_renovte) ✗
```