### PR TITLE
Catalog Migrator: iceberg and polaris version bump

### DIFF
--- a/iceberg-catalog-migrator/cli/build.gradle.kts
+++ b/iceberg-catalog-migrator/cli/build.gradle.kts
@@ -185,6 +185,7 @@ val shadowJar =
       "DISCLAIMER",
       "META-INF/DISCLAIMER",
       "META-INF/ASL2.0",
+      "META-INF/versions/9/OSGI-INF/MANIFEST.MF",
 
       // Proguard configurations used during the Guava build (don't care about those)
       "META-INF/proguard/**",

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/PolarisContainer.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/PolarisContainer.java
@@ -37,8 +37,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class PolarisContainer extends GenericContainer<PolarisContainer> {
 
-  private static final DockerImageName IMAGE =
-      DockerImageName.parse("apache/polaris:1.1.0-incubating");
+  private static final DockerImageName IMAGE = DockerImageName.parse("apache/polaris:1.6.0");
   private static final int POLARIS_PORT = 8181;
 
   public static final String CATALOG_NAME = "test";

--- a/iceberg-catalog-migrator/gradle/libs.versions.toml
+++ b/iceberg-catalog-migrator/gradle/libs.versions.toml
@@ -24,9 +24,9 @@ errorprone = "2.36.0"
 errorproneSlf4j = "0.1.28"
 googleJavaFormat = "1.25.2"
 guava = "33.4.0-jre"
-hadoop = "3.4.1" # this is in mapping with iceberg repo.
+hadoop = "3.4.3" # this is in mapping with iceberg repo.
 hive = { strictly = "2.3.10"} # this is in mapping with iceberg repo.
-iceberg = "1.10.0"
+iceberg = "1.11.0"
 immutables = "2.10.1"
 jacoco = "0.8.12"
 jandex = "3.2.3"


### PR DESCRIPTION
This is a base for the upcoming PR to support the register view functionality from latest Iceberg and polaris. 