### PR TITLE
CI: Replace blocked Gradle action

### DIFF
--- a/.github/workflows/apprunner-ci.yml
+++ b/.github/workflows/apprunner-ci.yml
@@ -59,15 +59,7 @@ jobs:
             21
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
           distribution: 'temurin'
-
-      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
-        with:
-          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
-          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
-          validate-wrappers: false
+          cache: gradle
 
       - name: Code style checks and tests
         run: |

--- a/.github/workflows/benchmarks-main.yml
+++ b/.github/workflows/benchmarks-main.yml
@@ -50,9 +50,7 @@ jobs:
           java-version: |
             21
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+          cache: gradle
 
       - name: Build & Check
         run: |

--- a/.github/workflows/iceberg-catalog-migrator-main.yml
+++ b/.github/workflows/iceberg-catalog-migrator-main.yml
@@ -50,9 +50,7 @@ jobs:
           java-version: |
             21
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+          cache: gradle
 
       - name: Build & Check
         run: |

--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -67,8 +67,7 @@ jobs:
           java-version: |
             21
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+          cache: gradle
 
       - name: Check
         run: |

--- a/.github/workflows/polaris-synchronizer-main.yml
+++ b/.github/workflows/polaris-synchronizer-main.yml
@@ -50,8 +50,7 @@ jobs:
           java-version: |
             21
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+          cache: gradle
 
       - name: Build & Check
         run: |

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/BenchmarkConfig.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/BenchmarkConfig.scala
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 object BenchmarkConfig {
   val config: BenchmarkConfig = apply()
 
-  private def readHeaders(http: Config): Map[String, String] = {
+  private def readHeaders(http: Config): Map[String, String] =
     if (http.hasPath("headers")) {
       val headersConfig = http.getConfig("headers")
       val result = collection.mutable.Map[String, String]()
@@ -36,7 +36,6 @@ object BenchmarkConfig {
     } else {
       Map.empty[String, String]
     }
-  }
 
   def apply(): BenchmarkConfig = {
     val config: Config = ConfigFactory.load().withFallback(ConfigFactory.load("benchmark-defaults"))

--- a/polaris-synchronizer/cli/build.gradle.kts
+++ b/polaris-synchronizer/cli/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
   `java-library`
   `maven-publish`
   signing
-  id("com.github.johnrengelman.shadow") version "8.1.1"
+  id("com.gradleup.shadow") version "9.3.2"
 }
 
 repositories {


### PR DESCRIPTION
Replace the blocked gradle/actions/setup-gradle action with GitHub-owned Gradle caching via actions/setup-java across all Gradle-based workflows.

Observed that PR builder was not running
https://github.com/apache/polaris-tools/actions/runs/29258683748


`The action gradle/actions/setup-gradle@v4 is not allowed in apache/polaris-tools because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: `