### PR TITLE
CI: Update setup-gradle action version

### DIFF
--- a/.github/workflows/apprunner-ci.yml
+++ b/.github/workflows/apprunner-ci.yml
@@ -63,7 +63,7 @@ jobs:
       # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
           # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.

--- a/.github/workflows/benchmarks-main.yml
+++ b/.github/workflows/benchmarks-main.yml
@@ -52,7 +52,7 @@ jobs:
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Build & Check
         run: |

--- a/.github/workflows/iceberg-catalog-migrator-main.yml
+++ b/.github/workflows/iceberg-catalog-migrator-main.yml
@@ -52,7 +52,7 @@ jobs:
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Build & Check
         run: |

--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -68,7 +68,7 @@ jobs:
             21
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Check
         run: |

--- a/.github/workflows/polaris-synchronizer-main.yml
+++ b/.github/workflows/polaris-synchronizer-main.yml
@@ -51,7 +51,7 @@ jobs:
             21
             ${{ matrix.java-version != '21' && matrix.java-version || '' }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Build & Check
         run: |

--- a/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/BenchmarkConfig.scala
+++ b/benchmarks/src/gatling/scala/org/apache/polaris/benchmarks/parameters/BenchmarkConfig.scala
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 object BenchmarkConfig {
   val config: BenchmarkConfig = apply()
 
-  private def readHeaders(http: Config): Map[String, String] = {
+  private def readHeaders(http: Config): Map[String, String] =
     if (http.hasPath("headers")) {
       val headersConfig = http.getConfig("headers")
       val result = collection.mutable.Map[String, String]()
@@ -36,7 +36,6 @@ object BenchmarkConfig {
     } else {
       Map.empty[String, String]
     }
-  }
 
   def apply(): BenchmarkConfig = {
     val config: Config = ConfigFactory.load().withFallback(ConfigFactory.load("benchmark-defaults"))

--- a/polaris-synchronizer/cli/build.gradle.kts
+++ b/polaris-synchronizer/cli/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
   `java-library`
   `maven-publish`
   signing
-  id("com.github.johnrengelman.shadow") version "8.1.1"
+  id("com.gradleup.shadow") version "9.3.2"
 }
 
 repositories {


### PR DESCRIPTION
Observed that PR builder was not running
https://github.com/apache/polaris-tools/actions/runs/29258683748

`The action gradle/actions/setup-gradle@v4 is not allowed in apache/polaris-tools because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: `

Bumped the version to be same as polaris main. 