### PR TITLE
Fix console 404 issue when accessing via domain_name

### DIFF
--- a/console/docker/Dockerfile
+++ b/console/docker/Dockerfile
@@ -50,8 +50,8 @@ RUN groupadd --gid 10001 polaris && \
 COPY LICENSE-BUNDLE /LICENSE
 COPY NOTICE /NOTICE
 
-# Copy custom nginx configuration as template
-COPY docker/nginx.conf /opt/app-root/etc/nginx.d/default.conf.template
+# Copy location blocks into the UBI default server block via nginx.default.d include
+COPY docker/nginx.conf /opt/app-root/etc/nginx.default.d/default.conf
 # Copy runtime config generation script
 COPY --chown=10000:10001 --chmod=744 docker/generate-config.sh /generate-config.sh
 # Copy built application from builder stage

--- a/console/docker/generate-config.sh
+++ b/console/docker/generate-config.sh
@@ -16,11 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Copy nginx configuration (no substitution needed since we use direct API calls)
-cp /opt/app-root/etc/nginx.d/default.conf.template /opt/app-root/etc/nginx.d/default.conf
-
-echo "Configured nginx for static file serving"
-
 # Generate runtime configuration from environment variables
 cat > /opt/app-root/src/config.js << EOF
 // Runtime configuration generated from environment variables

--- a/console/docker/nginx.conf
+++ b/console/docker/nginx.conf
@@ -15,12 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-server {
-    listen 8080;
-    server_name localhost;
-    root /opt/app-root/src;
-    index index.html;
-
     # Gzip compression
     gzip on;
     gzip_vary on;
@@ -31,6 +25,8 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
+
+    index index.html;
 
     # Serve static files
     location / {
@@ -56,4 +52,3 @@ server {
         return 200 "healthy\n";
         add_header Content-Type text/plain;
     }
-}


### PR DESCRIPTION
This PR fix issue reported in https://github.com/apache/polaris-tools/issues/249.

So what happened here is we changed the console port number from original 80 (which caused issue in https://github.com/apache/polaris-tools/issues/231) to 4040 then changed to 8080 during recent helm re-work as suggested by the team (8080 for console, 8181 for polaris api, and 8182 for polaris metrics). However, this caused one issue when accessing console via domain name where end-users would be getting 404 for all endpoints. But this doesn't cause issue when accessing via `localhost` via port forwarding.

Now this is actually due to the incorrect way of how we are using the Nginx UBI image. Following is the snippet for default `nginx.conf`. 
```
...
    # Load modular configuration files from the /etc/nginx/conf.d directory.
    # See http://nginx.org/en/docs/ngx_core_module.html#include
    # for more information.
    include /opt/app-root/etc/nginx.d/*.conf;

    server {
        listen       8080 default_server;
        listen       [::]:8080 default_server;
        server_name  _;
        root         /opt/app-root/src;

        # Load configuration files for the default server block.
        include /opt/app-root/etc/nginx.default.d/*.conf;
    }
}
...
```

What the dockerfile was doing earlier was creating a new server section via `include /opt/app-root/etc/nginx.d/*.conf;`. This was not a problem when we are using non-8080 port as that new server section would captured all. However, as we are using port 8080 with `server_name localhost`, it will covered the usage when accesing via 8080. The problem comes when we are using domain as the newly added server section won't catch it anymore and it will fall into second (original) one which yield 404.

The fix in this PR is to ensure we only have one server running for nginx by inject our location blocks inside the UBI's existing default server.

Validation for both access via localhost as well as a dummy local domain:

dummy local domain:
<img width="1720" height="807" alt="image" src="https://github.com/user-attachments/assets/7e16c8f0-8427-4702-a990-ca04baba547b" />
localhost:
<img width="1720" height="807" alt="image" src="https://github.com/user-attachments/assets/d25762f1-555c-4050-86cb-5287b0d4704f" />

