### PR TITLE
Synchronizer: Add --skip-iceberg-content flag to speed up DR-oriented syncs

### DIFF
--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
@@ -63,6 +63,8 @@ public class PolarisSynchronizer {
 
   private final boolean diffOnly;
 
+  private final boolean skipIcebergContent;
+
   public PolarisSynchronizer(
       Logger clientLogger,
       boolean haltOnFailure,
@@ -70,7 +72,8 @@ public class PolarisSynchronizer {
       PolarisService source,
       PolarisService target,
       ETagManager etagManager,
-      boolean diffOnly) {
+      boolean diffOnly,
+      boolean skipIcebergContent) {
     this.clientLogger =
         clientLogger == null ? LoggerFactory.getLogger(PolarisSynchronizer.class) : clientLogger;
     this.haltOnFailure = haltOnFailure;
@@ -79,6 +82,7 @@ public class PolarisSynchronizer {
     this.target = target;
     this.etagManager = etagManager;
     this.diffOnly = diffOnly;
+    this.skipIcebergContent = skipIcebergContent;
   }
 
   /**
@@ -635,27 +639,33 @@ public class PolarisSynchronizer {
 
     for (Catalog catalog : catalogSyncPlan.entitiesToSyncChildren()) {
 
-      try (IcebergCatalogService sourceIcebergCatalogService = source.initializeIcebergCatalogService(catalog.getName())) {
+      if (skipIcebergContent) {
         clientLogger.info(
-                "Initialized Iceberg REST catalog for Polaris catalog {} on source.",
+                "Skipping Iceberg namespace/table synchronization for catalog {}.",
                 catalog.getName());
-
-        try (IcebergCatalogService targetIcebergCatalogService = target.initializeIcebergCatalogService(catalog.getName())) {
+      } else {
+        try (IcebergCatalogService sourceIcebergCatalogService = source.initializeIcebergCatalogService(catalog.getName())) {
           clientLogger.info(
-                  "Initialized Iceberg REST catalog for Polaris catalog {} on target.",
+                  "Initialized Iceberg REST catalog for Polaris catalog {} on source.",
                   catalog.getName());
 
-          syncNamespaces(
-                  catalog.getName(), Namespace.empty(), sourceIcebergCatalogService, targetIcebergCatalogService);
-        }
+          try (IcebergCatalogService targetIcebergCatalogService = target.initializeIcebergCatalogService(catalog.getName())) {
+            clientLogger.info(
+                    "Initialized Iceberg REST catalog for Polaris catalog {} on target.",
+                    catalog.getName());
 
-      } catch (Exception e) {
-        clientLogger.error(
-                "Failed to synchronize Iceberg REST catalog for Polaris catalog {}.",
-                catalog.getName(),
-                e);
-        if (haltOnFailure) throw new RuntimeException(e);
-        continue;
+            syncNamespaces(
+                    catalog.getName(), Namespace.empty(), sourceIcebergCatalogService, targetIcebergCatalogService);
+          }
+
+        } catch (Exception e) {
+          clientLogger.error(
+                  "Failed to synchronize Iceberg REST catalog for Polaris catalog {}.",
+                  catalog.getName(),
+                  e);
+          if (haltOnFailure) throw new RuntimeException(e);
+          continue;
+        }
       }
 
       // NOTE: Grants are synced on a per catalog role basis, so we need to ensure that catalog roles

--- a/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizerSkipIcebergContentTest.java
+++ b/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizerSkipIcebergContentTest.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.tools.sync.polaris;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
+import org.apache.polaris.core.admin.model.Catalog;
+import org.apache.polaris.core.admin.model.CatalogProperties;
+import org.apache.polaris.core.admin.model.CatalogRole;
+import org.apache.polaris.core.admin.model.GrantResource;
+import org.apache.polaris.core.admin.model.Principal;
+import org.apache.polaris.core.admin.model.PrincipalRole;
+import org.apache.polaris.core.admin.model.PrincipalWithCredentials;
+import org.apache.polaris.core.admin.model.PolarisCatalog;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.apache.polaris.tools.sync.polaris.catalog.NoOpETagManager;
+import org.apache.polaris.tools.sync.polaris.planning.NoOpSyncPlanner;
+import org.apache.polaris.tools.sync.polaris.planning.plan.SynchronizationPlan;
+import org.apache.polaris.tools.sync.polaris.service.IcebergCatalogService;
+import org.apache.polaris.tools.sync.polaris.service.PolarisService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@code --skip-iceberg-content} prevents {@link PolarisSynchronizer#syncCatalogs()}
+ * from ever initializing an Iceberg REST catalog session, while still synchronizing catalog roles.
+ */
+public class PolarisSynchronizerSkipIcebergContentTest {
+
+  private static final Catalog catalog =
+      new PolarisCatalog()
+          .name("catalog")
+          .type(Catalog.TypeEnum.INTERNAL)
+          .properties(new CatalogProperties())
+          .storageConfigInfo(
+              new AwsStorageConfigInfo()
+                  .storageType(StorageConfigInfo.StorageTypeEnum.S3)
+                  .roleArn("roleArn")
+                  .userArn("userArn")
+                  .externalId("externalId")
+                  .region("region"));
+
+  private static final CatalogRole catalogRole = new CatalogRole().name("catalog-role");
+
+  private static final GrantResource tableScopedGrant =
+      new GrantResource().type(GrantResource.TypeEnum.TABLE);
+
+  /** Planner that always presents {@link #catalog} as needing its children synced. */
+  private static class SingleCatalogPlanner extends NoOpSyncPlanner {
+    @Override
+    public SynchronizationPlan<Catalog> planCatalogSync(
+        List<Catalog> catalogsOnSource, List<Catalog> catalogsOnTarget) {
+      SynchronizationPlan<Catalog> plan = new SynchronizationPlan<>();
+      plan.skipEntity(catalog);
+      return plan;
+    }
+
+    @Override
+    public SynchronizationPlan<Namespace> planNamespaceSync(
+        String catalogName,
+        Namespace namespace,
+        List<Namespace> namespacesOnSource,
+        List<Namespace> namespacesOnTarget) {
+      // NoOpSyncPlanner returns null here, which would NPE once syncNamespaces() runs.
+      return new SynchronizationPlan<>();
+    }
+  }
+
+  /**
+   * Planner that, in addition to {@link SingleCatalogPlanner}'s behavior, always presents
+   * {@link #catalogRole} as needing its children synced and always stages {@link #tableScopedGrant}
+   * for creation - regardless of whether the underlying table was ever synced.
+   */
+  private static class SingleCatalogWithGrantPlanner extends SingleCatalogPlanner {
+    @Override
+    public SynchronizationPlan<CatalogRole> planCatalogRoleSync(
+        String catalogName,
+        List<CatalogRole> catalogRolesOnSource,
+        List<CatalogRole> catalogRolesOnTarget) {
+      SynchronizationPlan<CatalogRole> plan = new SynchronizationPlan<>();
+      plan.skipEntity(catalogRole);
+      return plan;
+    }
+
+    @Override
+    public SynchronizationPlan<GrantResource> planGrantSync(
+        String catalogName,
+        String catalogRoleName,
+        List<GrantResource> grantsOnSource,
+        List<GrantResource> grantsOnTarget) {
+      SynchronizationPlan<GrantResource> plan = new SynchronizationPlan<>();
+      plan.createEntity(tableScopedGrant);
+      return plan;
+    }
+  }
+
+  private static class CountingIcebergCatalogService implements IcebergCatalogService {
+    @Override
+    public List<Namespace> listNamespaces(Namespace parentNamespace) {
+      return List.of();
+    }
+
+    @Override
+    public Map<String, String> loadNamespaceMetadata(Namespace namespace) {
+      return Map.of();
+    }
+
+    @Override
+    public void createNamespace(Namespace namespace, Map<String, String> namespaceMetadata) {}
+
+    @Override
+    public void setNamespaceProperties(Namespace namespace, Map<String, String> namespaceProperties) {}
+
+    @Override
+    public void dropNamespaceCascade(Namespace namespace) {}
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace) {
+      return List.of();
+    }
+
+    @Override
+    public Table loadTable(TableIdentifier tableIdentifier) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerTable(TableIdentifier tableIdentifier, String metadataFileLocation) {}
+
+    @Override
+    public void dropTableWithoutPurge(TableIdentifier tableIdentifier) {}
+
+    @Override
+    public void close() {}
+  }
+
+  /** Stub {@link PolarisService} that tracks how often Iceberg and catalog-role sync is attempted. */
+  private static class TrackingPolarisService implements PolarisService {
+
+    private final List<Catalog> catalogs;
+    final List<GrantResource> grantsAdded = new ArrayList<>();
+    int initializeIcebergCatalogServiceCalls = 0;
+    int listCatalogRolesCalls = 0;
+
+    TrackingPolarisService(List<Catalog> catalogs) {
+      this.catalogs = catalogs;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+
+    @Override
+    public List<Principal> listPrincipals() {
+      return List.of();
+    }
+
+    @Override
+    public Principal getPrincipal(String principalName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PrincipalWithCredentials createPrincipal(Principal principal) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropPrincipal(String principalName) {}
+
+    @Override
+    public List<PrincipalRole> listPrincipalRoles() {
+      return List.of();
+    }
+
+    @Override
+    public PrincipalRole getPrincipalRole(String principalRoleName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createPrincipalRole(PrincipalRole principalRole) {}
+
+    @Override
+    public void dropPrincipalRole(String principalRoleName) {}
+
+    @Override
+    public List<PrincipalRole> listPrincipalRolesAssigned(String principalName) {
+      return List.of();
+    }
+
+    @Override
+    public void assignPrincipalRole(String principalName, String principalRoleName) {}
+
+    @Override
+    public void revokePrincipalRole(String principalName, String principalRoleName) {}
+
+    @Override
+    public List<Catalog> listCatalogs() {
+      return catalogs;
+    }
+
+    @Override
+    public Catalog getCatalog(String catalogName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createCatalog(Catalog catalog) {}
+
+    @Override
+    public void dropCatalogCascade(String catalogName) {}
+
+    @Override
+    public List<CatalogRole> listCatalogRoles(String catalogName) {
+      listCatalogRolesCalls++;
+      return List.of();
+    }
+
+    @Override
+    public CatalogRole getCatalogRole(String catalogName, String catalogRoleName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createCatalogRole(String catalogName, CatalogRole catalogRole) {}
+
+    @Override
+    public void dropCatalogRole(String catalogName, String catalogRoleName) {}
+
+    @Override
+    public List<PrincipalRole> listAssigneePrincipalRolesForCatalogRole(
+        String catalogName, String catalogRoleName) {
+      return List.of();
+    }
+
+    @Override
+    public void assignCatalogRole(
+        String principalRoleName, String catalogName, String catalogRoleName) {}
+
+    @Override
+    public void revokeCatalogRole(
+        String principalRoleName, String catalogName, String catalogRoleName) {}
+
+    @Override
+    public List<GrantResource> listGrants(String catalogName, String catalogRoleName) {
+      return List.of();
+    }
+
+    @Override
+    public void addGrant(String catalogName, String catalogRoleName, GrantResource grant) {
+      grantsAdded.add(grant);
+    }
+
+    @Override
+    public void revokeGrant(String catalogName, String catalogRoleName, GrantResource grant) {}
+
+    @Override
+    public IcebergCatalogService initializeIcebergCatalogService(String catalogName) {
+      initializeIcebergCatalogServiceCalls++;
+      return new CountingIcebergCatalogService();
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  @Test
+  public void testSkipIcebergContentSkipsIcebergSyncButStillSyncsCatalogRoles() {
+    TrackingPolarisService source = new TrackingPolarisService(List.of(catalog));
+    TrackingPolarisService target = new TrackingPolarisService(List.of());
+
+    PolarisSynchronizer synchronizer =
+        new PolarisSynchronizer(
+            null,
+            false,
+            new SingleCatalogPlanner(),
+            source,
+            target,
+            new NoOpETagManager(),
+            false,
+            true);
+
+    synchronizer.syncCatalogs();
+
+    Assertions.assertEquals(0, source.initializeIcebergCatalogServiceCalls);
+    Assertions.assertEquals(0, target.initializeIcebergCatalogServiceCalls);
+    Assertions.assertEquals(1, source.listCatalogRolesCalls);
+    Assertions.assertEquals(1, target.listCatalogRolesCalls);
+  }
+
+  @Test
+  public void testIcebergContentSyncedWhenNotSkipped() {
+    TrackingPolarisService source = new TrackingPolarisService(List.of(catalog));
+    TrackingPolarisService target = new TrackingPolarisService(List.of());
+
+    PolarisSynchronizer synchronizer =
+        new PolarisSynchronizer(
+            null,
+            false,
+            new SingleCatalogPlanner(),
+            source,
+            target,
+            new NoOpETagManager(),
+            false,
+            false);
+
+    synchronizer.syncCatalogs();
+
+    Assertions.assertEquals(1, source.initializeIcebergCatalogServiceCalls);
+    Assertions.assertEquals(1, target.initializeIcebergCatalogServiceCalls);
+    Assertions.assertEquals(1, source.listCatalogRolesCalls);
+    Assertions.assertEquals(1, target.listCatalogRolesCalls);
+  }
+
+  /**
+   * Documents a known consequence of {@code --skip-iceberg-content}: grant sync is not scoped by
+   * grant type, so a TABLE- or NAMESPACE-scoped grant is still applied to the target even though the
+   * table/namespace it refers to was never synced. Against a real Polaris server this would likely
+   * fail server-side (grant referencing an unknown resource); this test only proves the client still
+   * attempts it.
+   */
+  @Test
+  public void testTableScopedGrantsStillAttemptedWhenIcebergContentSkipped() {
+    TrackingPolarisService source = new TrackingPolarisService(List.of(catalog));
+    TrackingPolarisService target = new TrackingPolarisService(List.of());
+
+    PolarisSynchronizer synchronizer =
+        new PolarisSynchronizer(
+            null,
+            false,
+            new SingleCatalogWithGrantPlanner(),
+            source,
+            target,
+            new NoOpETagManager(),
+            false,
+            true);
+
+    synchronizer.syncCatalogs();
+
+    Assertions.assertEquals(0, source.initializeIcebergCatalogServiceCalls);
+    Assertions.assertEquals(0, target.initializeIcebergCatalogServiceCalls);
+    Assertions.assertEquals(List.of(tableScopedGrant), target.grantsAdded);
+  }
+}

--- a/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
+++ b/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
@@ -105,6 +105,13 @@ public class SyncPolarisCommand implements Callable<Integer> {
   private boolean diffOnly;
 
   @CommandLine.Option(
+          names = {"--skip-iceberg-content"},
+          description = "Skip synchronization of Iceberg namespaces and tables. Catalogs, catalog-roles, and " +
+                  "grants will still be synchronized."
+  )
+  private boolean skipIcebergContent;
+
+  @CommandLine.Option(
           names = {"--strategy"},
           defaultValue = "CREATE_ONLY",
           description = "The synchronization strategy to use. Options: " +
@@ -145,7 +152,8 @@ public class SyncPolarisCommand implements Callable<Integer> {
                       source,
                       target,
                       etagManager,
-                      diffOnly);
+                      diffOnly,
+                      skipIcebergContent);
       synchronizer.syncPrincipalRoles();
       if (shouldSyncPrincipals) {
         consoleLog.warn("Principal migration will reset credentials on the target Polaris instance. " +


### PR DESCRIPTION

Add a `--skip-iceberg-content` flag to sync-polaris that skips walking and synchronizing Iceberg namespaces and tables for each catalog. Principals, principal-roles, catalogs, catalog-roles, and grants are still synchronized as before.

Motivation: disaster recovery
------------------------------
For teams running Polaris in an active/standby (or multi-region) topology, polaris-synchronizer is a convenient way to keep the *access control and catalog structure* of a standby instance in sync with the primary so that failover is fast - principals, principal-roles, catalogs, catalog-roles, and grants all need to exist ahead of time on the standby.

However, the default sync path also opens an Iceberg REST catalog session per catalog and recursively lists every namespace and table underneath it, which is the most expensive part of the sync and scales with the number of tables rather than the number of Polaris entities. For a DR-readiness sync that may run frequently (e.g. on a schedule) purely to keep entity/grant structure current, this Iceberg walk is unnecessary overhead - the actual Iceberg table metadata/content is typically already replicated by a separate, storage-level mechanism (e.g. object storage replication) rather than by this tool.

`--skip-iceberg-content` lets operators run frequent, lightweight structural syncs for DR readiness without paying the cost of a full namespace/table walk, while still running full syncs (without the flag) when an actual data migration is needed.

Known limitation
-----------------
Grant synchronization is not filtered by grant type, so a TABLE- or NAMESPACE-scoped grant on a catalog role is still synced to the target even when `--skip-iceberg-content` prevented that table/namespace from ever being created there. Against a real Polaris server this would likely fail server-side (grant referencing an unknown resource); with the default `--halt-on-failure=false` this fails silently per-grant rather than aborting the run. This is called out explicitly and covered by a test documenting the current behavior - narrowing grant sync to skip content-scoped grants when this flag is set is left as follow-up work.

Testing
-------
Added PolarisSynchronizerSkipIcebergContentTest covering:
- Iceberg REST catalog sessions are never initialized when the flag is set, while catalog-role sync still runs.
- Original (Iceberg content synced) behavior is unchanged when the flag is not set.
- Documents that TABLE-scoped grants are still attempted even when the underlying table was never synced (see Known limitation above).