### PR TITLE
Synchronizer: Add consolidated sync report and --fail-on-error flag

### DIFF
--- a/polaris-synchronizer/README.md
+++ b/polaris-synchronizer/README.md
@@ -184,3 +184,25 @@ java -jar cli/build/libs/polaris-synchronizer-cli.jar sync-polaris \
 > nor remove or modify them or their assignments to principals/principal-roles on the target. This is to accommodate that 
 > the tool itself will be running with the permission levels for these principals and roles, and we do not want to modify 
 > the tool's permissions at runtime.
+
+At the end of every run, `sync-polaris` prints a consolidated synchronization report summarizing how
+many entities of each type were created, overwritten, removed, skipped (already in sync), or failed,
+along with a list of any failures encountered:
+
+```
+=== Synchronization Report ===
+Principal:               3 created, 0 overwritten, 0 removed, 0 skipped, 1 failed
+Catalog:                  2 created, 1 overwritten, 0 removed, 5 skipped, 0 failed
+Table:                   20 created, 0 overwritten, 0 removed, 40 skipped, 2 failed
+
+Failures:
+  - Principal 'alice': <exception message>
+  - Table 'db.orders': <exception message>
+===============================
+```
+
+By default, `sync-polaris` exits with status `0` regardless of whether individual entities failed to
+synchronize (matching the pre-existing behavior, where failures are logged and the run continues).
+Pass `--fail-on-error` to make the command exit with a non-zero status if the report contains any
+failures. This is distinct from `--halt-on-failure`, which aborts the run as soon as the first failure
+occurs; `--fail-on-error` lets the run finish synchronizing everything it can, then fails afterward.

--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
@@ -36,7 +36,10 @@ import org.apache.polaris.tools.sync.polaris.catalog.BaseTableWithETag;
 import org.apache.polaris.tools.sync.polaris.catalog.ETagManager;
 import org.apache.polaris.tools.sync.polaris.catalog.MetadataNotModifiedException;
 import org.apache.polaris.tools.sync.polaris.planning.SynchronizationPlanner;
+import org.apache.polaris.tools.sync.polaris.planning.plan.EntityType;
+import org.apache.polaris.tools.sync.polaris.planning.plan.SyncOutcome;
 import org.apache.polaris.tools.sync.polaris.planning.plan.SynchronizationPlan;
+import org.apache.polaris.tools.sync.polaris.planning.plan.SynchronizationReport;
 import org.apache.polaris.tools.sync.polaris.service.IcebergCatalogService;
 import org.apache.polaris.tools.sync.polaris.service.PolarisService;
 import org.apache.polaris.tools.sync.polaris.service.impl.PolarisIcebergCatalogService;
@@ -63,6 +66,8 @@ public class PolarisSynchronizer {
 
   private final boolean diffOnly;
 
+  private final SynchronizationReport report;
+
   public PolarisSynchronizer(
       Logger clientLogger,
       boolean haltOnFailure,
@@ -70,7 +75,8 @@ public class PolarisSynchronizer {
       PolarisService source,
       PolarisService target,
       ETagManager etagManager,
-      boolean diffOnly) {
+      boolean diffOnly,
+      SynchronizationReport report) {
     this.clientLogger =
         clientLogger == null ? LoggerFactory.getLogger(PolarisSynchronizer.class) : clientLogger;
     this.haltOnFailure = haltOnFailure;
@@ -79,6 +85,7 @@ public class PolarisSynchronizer {
     this.target = target;
     this.etagManager = etagManager;
     this.diffOnly = diffOnly;
+    this.report = report;
   }
 
   /**
@@ -123,16 +130,20 @@ public class PolarisSynchronizer {
     principalSyncPlan
             .entitiesToSkipAndSkipChildren()
             .forEach(
-                    principal ->
-                            clientLogger.info("Skipping principal {}.", principal.getName()));
+                    principal -> {
+                            clientLogger.info("Skipping principal {}.", principal.getName());
+                            report.recordSuccess(EntityType.PRINCIPAL, SyncOutcome.SKIPPED);
+                    });
 
     principalSyncPlan
             .entitiesNotModified()
             .forEach(
-                    principal ->
+                    principal -> {
                             clientLogger.info(
                                     "No change detected for principal {}, skipping.",
-                                    principal.getName()));
+                                    principal.getName());
+                            report.recordSuccess(EntityType.PRINCIPAL, SyncOutcome.SKIPPED);
+                    });
 
     int syncsCompleted = 0;
     final int totalSyncsToComplete = totalSyncsToComplete(principalSyncPlan);
@@ -147,10 +158,12 @@ public class PolarisSynchronizer {
                 ++syncsCompleted,
                 totalSyncsToComplete
         );
+        report.recordSuccess(EntityType.PRINCIPAL, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error("Failed to create principal {} on target. - {}/{}",
                 principal.getName(), ++syncsCompleted, totalSyncsToComplete, e);
+        report.recordFailure(EntityType.PRINCIPAL, principal.getName(), e);
       }
     }
 
@@ -165,10 +178,12 @@ public class PolarisSynchronizer {
                 ++syncsCompleted,
                 totalSyncsToComplete
         );
+        report.recordSuccess(EntityType.PRINCIPAL, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error("Failed to overwrite principal {} on target. - {}/{}",
                 principal.getName(), ++syncsCompleted, totalSyncsToComplete, e);
+        report.recordFailure(EntityType.PRINCIPAL, principal.getName(), e);
       }
     }
 
@@ -177,10 +192,12 @@ public class PolarisSynchronizer {
         target.dropPrincipal(principal.getName());
         clientLogger.info("Removed principal {} on target. - {}/{}",
                 principal.getName(), ++syncsCompleted, totalSyncsToComplete);
+        report.recordSuccess(EntityType.PRINCIPAL, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error("Failed to remove principal {} ont target. - {}/{}",
                 principal.getName(), ++syncsCompleted, totalSyncsToComplete, e);
+        report.recordFailure(EntityType.PRINCIPAL, principal.getName(), e);
       }
     }
 
@@ -225,17 +242,21 @@ public class PolarisSynchronizer {
     assignedPrincipalRoleSyncPlan
             .entitiesToSkip()
             .forEach(
-                    principalRole ->
+                    principalRole -> {
                             clientLogger.info("Skipping assignment of principal-role {} to principal {}.",
-                                    principalName, principalRole.getName()));
+                                    principalName, principalRole.getName());
+                            report.recordSuccess(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, SyncOutcome.SKIPPED);
+                    });
 
     assignedPrincipalRoleSyncPlan
             .entitiesNotModified()
             .forEach(
-                    principalRole ->
+                    principalRole -> {
                             clientLogger.info(
                                     "Principal {} is already assigned to principal-role {}, skipping.",
-                                    principalName, principalRole.getName()));
+                                    principalName, principalRole.getName());
+                            report.recordSuccess(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, SyncOutcome.SKIPPED);
+                    });
 
     int syncsCompleted = 0;
     final int totalSyncsToComplete = totalSyncsToComplete(assignedPrincipalRoleSyncPlan);
@@ -245,10 +266,12 @@ public class PolarisSynchronizer {
         target.assignPrincipalRole(principalName, principalRole.getName());
         clientLogger.info("Assigned principal-role {} to principal {}. - {}/{}",
                 principalRole.getName(), principalName, ++syncsCompleted, totalSyncsToComplete);
+        report.recordSuccess(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error("Failed to assign principal-role {} to principal {}. - {}/{}",
                 principalRole.getName(), principalName, ++syncsCompleted, totalSyncsToComplete);
+        report.recordFailure(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, principalRole.getName(), e);
       }
     }
 
@@ -257,10 +280,12 @@ public class PolarisSynchronizer {
         target.assignPrincipalRole(principalName, principalRole.getName());
         clientLogger.info("Assigned principal-role {} to principal {}. - {}/{}",
                 principalRole.getName(), principalName, ++syncsCompleted, totalSyncsToComplete);
+        report.recordSuccess(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error("Failed to assign principal-role {} to principal {}. - {}/{}",
                 principalRole.getName(), principalName, ++syncsCompleted, totalSyncsToComplete);
+        report.recordFailure(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, principalRole.getName(), e);
       }
     }
 
@@ -269,10 +294,12 @@ public class PolarisSynchronizer {
         target.revokePrincipalRole(principalName, principalRole.getName());
         clientLogger.info("Revoked principal-role {} from principal {}. - {}/{}",
                 principalRole.getName(), principalName, ++syncsCompleted, totalSyncsToComplete);
+        report.recordSuccess(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error("Failed to revoke principal-role {} to principal {}. - {}/{}",
                 principalRole.getName(), principalName, ++syncsCompleted, totalSyncsToComplete);
+        report.recordFailure(EntityType.PRINCIPAL_ROLE_ASSIGNMENT, principalRole.getName(), e);
       }
     }
   }
@@ -307,16 +334,20 @@ public class PolarisSynchronizer {
     principalRoleSyncPlan
         .entitiesToSkip()
         .forEach(
-            principalRole ->
-                clientLogger.info("Skipping principal-role {}.", principalRole.getName()));
+            principalRole -> {
+                clientLogger.info("Skipping principal-role {}.", principalRole.getName());
+                report.recordSuccess(EntityType.PRINCIPAL_ROLE, SyncOutcome.SKIPPED);
+            });
 
     principalRoleSyncPlan
         .entitiesNotModified()
         .forEach(
-            principalRole ->
+            principalRole -> {
                 clientLogger.info(
                     "No change detected for principal-role {}, skipping.",
-                    principalRole.getName()));
+                    principalRole.getName());
+                report.recordSuccess(EntityType.PRINCIPAL_ROLE, SyncOutcome.SKIPPED);
+            });
 
     int syncsCompleted = 0;
     final int totalSyncsToComplete = totalSyncsToComplete(principalRoleSyncPlan);
@@ -329,6 +360,7 @@ public class PolarisSynchronizer {
             principalRole.getName(),
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.PRINCIPAL_ROLE, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -337,6 +369,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.PRINCIPAL_ROLE, principalRole.getName(), e);
       }
     }
 
@@ -349,6 +382,7 @@ public class PolarisSynchronizer {
             principalRole.getName(),
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.PRINCIPAL_ROLE, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -357,6 +391,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.PRINCIPAL_ROLE, principalRole.getName(), e);
       }
     }
 
@@ -368,6 +403,7 @@ public class PolarisSynchronizer {
             principalRole.getName(),
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.PRINCIPAL_ROLE, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -376,6 +412,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.PRINCIPAL_ROLE, principalRole.getName(), e);
       }
     }
   }
@@ -434,22 +471,26 @@ public class PolarisSynchronizer {
     assignedPrincipalRoleSyncPlan
         .entitiesToSkip()
         .forEach(
-            principalRole ->
+            principalRole -> {
                 clientLogger.info(
                     "Skipping assignment of principal-role {} to catalog-role {} in catalog {}.",
                     principalRole.getName(),
                     catalogRoleName,
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.CATALOG_ROLE_ASSIGNMENT, SyncOutcome.SKIPPED);
+            });
 
     assignedPrincipalRoleSyncPlan
         .entitiesNotModified()
         .forEach(
-            principalRole ->
+            principalRole -> {
                 clientLogger.info(
                     "Principal-role {} is already assigned to catalog-role {} in catalog {}. Skipping.",
                     principalRole.getName(),
                     catalogRoleName,
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.CATALOG_ROLE_ASSIGNMENT, SyncOutcome.SKIPPED);
+            });
 
     int syncsCompleted = 0;
     int totalSyncsToComplete = totalSyncsToComplete(assignedPrincipalRoleSyncPlan);
@@ -465,6 +506,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG_ROLE_ASSIGNMENT, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -475,6 +517,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG_ROLE_ASSIGNMENT, principalRole.getName(), e);
       }
     }
 
@@ -489,6 +532,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG_ROLE_ASSIGNMENT, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -499,6 +543,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG_ROLE_ASSIGNMENT, principalRole.getName(), e);
       }
     }
 
@@ -513,6 +558,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG_ROLE_ASSIGNMENT, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -523,6 +569,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG_ROLE_ASSIGNMENT, principalRole.getName(), e);
       }
     }
   }
@@ -556,21 +603,28 @@ public class PolarisSynchronizer {
 
     catalogSyncPlan
         .entitiesToSkip()
-        .forEach(catalog -> clientLogger.info("Skipping catalog {}.", catalog.getName()));
+        .forEach(catalog -> {
+            clientLogger.info("Skipping catalog {}.", catalog.getName());
+            report.recordSuccess(EntityType.CATALOG, SyncOutcome.SKIPPED);
+        });
 
     catalogSyncPlan
         .entitiesToSkipAndSkipChildren()
         .forEach(
-            catalog ->
+            catalog -> {
                 clientLogger.info(
-                    "Skipping catalog {} and all child entities.", catalog.getName()));
+                    "Skipping catalog {} and all child entities.", catalog.getName());
+                report.recordSuccess(EntityType.CATALOG, SyncOutcome.SKIPPED);
+            });
 
     catalogSyncPlan
         .entitiesNotModified()
         .forEach(
-            catalog ->
+            catalog -> {
                 clientLogger.info(
-                    "No change detected in catalog {}. Skipping.", catalog.getName()));
+                    "No change detected in catalog {}. Skipping.", catalog.getName());
+                report.recordSuccess(EntityType.CATALOG, SyncOutcome.SKIPPED);
+            });
 
     int syncsCompleted = 0;
     int totalSyncsToComplete = totalSyncsToComplete(catalogSyncPlan);
@@ -583,6 +637,7 @@ public class PolarisSynchronizer {
             catalog.getName(),
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -591,6 +646,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG, catalog.getName(), e);
       }
     }
 
@@ -603,6 +659,7 @@ public class PolarisSynchronizer {
             catalog.getName(),
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -611,6 +668,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG, catalog.getName(), e);
       }
     }
 
@@ -622,6 +680,7 @@ public class PolarisSynchronizer {
             catalog.getName(),
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -630,6 +689,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG, catalog.getName(), e);
       }
     }
 
@@ -654,6 +714,7 @@ public class PolarisSynchronizer {
                 "Failed to synchronize Iceberg REST catalog for Polaris catalog {}.",
                 catalog.getName(),
                 e);
+        report.recordFailure(EntityType.CATALOG, catalog.getName(), e);
         if (haltOnFailure) throw new RuntimeException(e);
         continue;
       }
@@ -707,27 +768,33 @@ public class PolarisSynchronizer {
     catalogRoleSyncPlan
         .entitiesToSkip()
         .forEach(
-            catalogRole ->
+            catalogRole -> {
                 clientLogger.info(
-                    "Skipping catalog-role {} in catalog {}.", catalogRole.getName(), catalogName));
+                    "Skipping catalog-role {} in catalog {}.", catalogRole.getName(), catalogName);
+                report.recordSuccess(EntityType.CATALOG_ROLE, SyncOutcome.SKIPPED);
+            });
 
     catalogRoleSyncPlan
         .entitiesToSkipAndSkipChildren()
         .forEach(
-            catalogRole ->
+            catalogRole -> {
                 clientLogger.info(
                     "Skipping catalog-role {} in catalog {} and all child entities.",
                     catalogRole.getName(),
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.CATALOG_ROLE, SyncOutcome.SKIPPED);
+            });
 
     catalogRoleSyncPlan
         .entitiesNotModified()
         .forEach(
-            catalogRole ->
+            catalogRole -> {
                 clientLogger.info(
                     "No change detected in catalog-role {} in catalog {}. Skipping.",
                     catalogRole.getName(),
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.CATALOG_ROLE, SyncOutcome.SKIPPED);
+            });
 
     int syncsCompleted = 0;
     int totalSyncsToComplete = totalSyncsToComplete(catalogRoleSyncPlan);
@@ -741,6 +808,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG_ROLE, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -750,6 +818,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG_ROLE, catalogRole.getName(), e);
       }
     }
 
@@ -763,6 +832,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG_ROLE, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -772,6 +842,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG_ROLE, catalogRole.getName(), e);
       }
     }
 
@@ -784,6 +855,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.CATALOG_ROLE, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -793,6 +865,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.CATALOG_ROLE, catalogRole.getName(), e);
       }
     }
 
@@ -853,22 +926,26 @@ public class PolarisSynchronizer {
     grantSyncPlan
         .entitiesToSkip()
         .forEach(
-            grant ->
+            grant -> {
                 clientLogger.info(
                     "Skipping addition of grant {} to catalog-role {} in catalog {}.",
                     grant.getType(),
                     catalogRoleName,
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.GRANT, SyncOutcome.SKIPPED);
+            });
 
     grantSyncPlan
         .entitiesNotModified()
         .forEach(
-            grant ->
+            grant -> {
                 clientLogger.info(
                     "Grant {} was already added to catalog-role {} in catalog {}. Skipping.",
                     grant.getType(),
                     catalogRoleName,
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.GRANT, SyncOutcome.SKIPPED);
+            });
 
     int syncsCompleted = 0;
     int totalSyncsToComplete = totalSyncsToComplete(grantSyncPlan);
@@ -883,6 +960,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.GRANT, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -893,6 +971,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.GRANT, grant.getType().toString(), e);
       }
     }
 
@@ -906,6 +985,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.GRANT, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -916,6 +996,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.GRANT, grant.getType().toString(), e);
       }
     }
 
@@ -929,6 +1010,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.GRANT, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -939,6 +1021,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.GRANT, grant.getType().toString(), e);
       }
     }
   }
@@ -1004,12 +1087,14 @@ public class PolarisSynchronizer {
     namespaceSynchronizationPlan
         .entitiesNotModified()
         .forEach(
-            namespace ->
+            namespace -> {
                 clientLogger.info(
                     "No change detected for namespace {} in namespace {} for catalog {}, skipping.",
                     namespace,
                     parentNamespace,
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.NAMESPACE, SyncOutcome.SKIPPED);
+            });
 
     for (Namespace namespace : namespaceSynchronizationPlan.entitiesToCreate()) {
       try {
@@ -1022,6 +1107,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.NAMESPACE, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -1032,6 +1118,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.NAMESPACE, namespace.toString(), e);
       }
     }
 
@@ -1056,6 +1143,7 @@ public class PolarisSynchronizer {
                     catalogName,
                     ++syncsCompleted,
                     totalSyncsToComplete);
+            report.recordSuccess(EntityType.NAMESPACE, SyncOutcome.SKIPPED);
             continue;
           }
         }
@@ -1069,6 +1157,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.NAMESPACE, SyncOutcome.OVERWRITTEN);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -1079,6 +1168,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.NAMESPACE, namespace.toString(), e);
       }
     }
 
@@ -1092,6 +1182,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.NAMESPACE, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -1102,6 +1193,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.NAMESPACE, namespace.toString(), e);
       }
     }
 
@@ -1168,12 +1260,14 @@ public class PolarisSynchronizer {
     tableSyncPlan
         .entitiesToSkip()
         .forEach(
-            tableId ->
+            tableId -> {
                 clientLogger.info(
                     "Skipping table {} in namespace {} in catalog {}.",
                     tableId,
                     namespace,
-                    catalogName));
+                    catalogName);
+                report.recordSuccess(EntityType.TABLE, SyncOutcome.SKIPPED);
+            });
 
     int syncsCompleted = 0;
     int totalSyncsToComplete = totalSyncsToComplete(tableSyncPlan);
@@ -1200,6 +1294,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.TABLE, SyncOutcome.CREATED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -1210,6 +1305,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.TABLE, tableId.toString(), e);
       }
     }
 
@@ -1243,6 +1339,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.TABLE, SyncOutcome.OVERWRITTEN);
       } catch (MetadataNotModifiedException e) {
         clientLogger.info(
             "Table {} in namespace {} in catalog {} with was not modified, not overwriting in target catalog. - {}/{}",
@@ -1251,6 +1348,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.TABLE, SyncOutcome.SKIPPED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.error(
@@ -1261,6 +1359,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.TABLE, tableId.toString(), e);
       }
     }
 
@@ -1274,6 +1373,7 @@ public class PolarisSynchronizer {
             catalogName,
             ++syncsCompleted,
             totalSyncsToComplete);
+        report.recordSuccess(EntityType.TABLE, SyncOutcome.REMOVED);
       } catch (Exception e) {
         if (haltOnFailure) throw e;
         clientLogger.info(
@@ -1284,6 +1384,7 @@ public class PolarisSynchronizer {
             ++syncsCompleted,
             totalSyncsToComplete,
             e);
+        report.recordFailure(EntityType.TABLE, table.toString(), e);
       }
     }
   }

--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
@@ -77,7 +77,7 @@ public class PolarisSynchronizer {
       PolarisService target,
       ETagManager etagManager,
       boolean diffOnly,
-      SynchronizationReport report) {
+      SynchronizationReport report,
       boolean skipIcebergContent) {
     this.clientLogger =
         clientLogger == null ? LoggerFactory.getLogger(PolarisSynchronizer.class) : clientLogger;

--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/plan/EntityType.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/plan/EntityType.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.tools.sync.polaris.planning.plan;
+
+/** The category of entity a {@link SynchronizationReport} outcome is recorded against. */
+public enum EntityType {
+  PRINCIPAL,
+  PRINCIPAL_ROLE,
+  PRINCIPAL_ROLE_ASSIGNMENT,
+  CATALOG,
+  CATALOG_ROLE,
+  CATALOG_ROLE_ASSIGNMENT,
+  GRANT,
+  NAMESPACE,
+  TABLE
+}

--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/plan/SyncOutcome.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/plan/SyncOutcome.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.tools.sync.polaris.planning.plan;
+
+/** The outcome of an individual entity sync attempt, recorded in a {@link SynchronizationReport}. */
+public enum SyncOutcome {
+  CREATED,
+  OVERWRITTEN,
+  REMOVED,
+  SKIPPED,
+  FAILED
+}

--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/plan/SynchronizationReport.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/planning/plan/SynchronizationReport.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.tools.sync.polaris.planning.plan;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Accumulates the outcome of every individual entity sync attempt performed during a run, so that
+ * a single consolidated summary can be printed at the end instead of relying on interleaved logs.
+ */
+public class SynchronizationReport {
+
+  private record Failure(EntityType type, String identifier, String message) {}
+
+  private final Map<EntityType, Map<SyncOutcome, Integer>> counts;
+
+  private final List<Failure> failures;
+
+  public SynchronizationReport() {
+    this.counts = new EnumMap<>(EntityType.class);
+    for (EntityType type : EntityType.values()) {
+      Map<SyncOutcome, Integer> outcomeCounts = new EnumMap<>(SyncOutcome.class);
+      for (SyncOutcome outcome : SyncOutcome.values()) {
+        outcomeCounts.put(outcome, 0);
+      }
+      this.counts.put(type, outcomeCounts);
+    }
+    this.failures = new ArrayList<>();
+  }
+
+  /**
+   * Records that an entity was successfully synced.
+   *
+   * @param type the category of entity that was synced
+   * @param outcome the outcome of the sync; must not be {@link SyncOutcome#FAILED} - use {@link
+   *     #recordFailure(EntityType, String, Exception)} for failures
+   */
+  public void recordSuccess(EntityType type, SyncOutcome outcome) {
+    if (outcome == SyncOutcome.FAILED) {
+      throw new IllegalArgumentException("Use recordFailure() to record a failed sync.");
+    }
+    Map<SyncOutcome, Integer> outcomeCounts = counts.get(type);
+    outcomeCounts.put(outcome, outcomeCounts.get(outcome) + 1);
+  }
+
+  /**
+   * Records that an entity failed to sync.
+   *
+   * @param type the category of entity that failed to sync
+   * @param identifier a human-readable identifier for the entity, e.g. its name
+   * @param cause the exception that caused the failure
+   */
+  public void recordFailure(EntityType type, String identifier, Exception cause) {
+    Map<SyncOutcome, Integer> outcomeCounts = counts.get(type);
+    outcomeCounts.put(SyncOutcome.FAILED, outcomeCounts.get(SyncOutcome.FAILED) + 1);
+    failures.add(new Failure(type, identifier, cause.getMessage()));
+  }
+
+  /** Returns true if any entity failed to sync. */
+  public boolean hasFailures() {
+    return !failures.isEmpty();
+  }
+
+  private static String displayName(EntityType type) {
+    return switch (type) {
+      case PRINCIPAL -> "Principal";
+      case PRINCIPAL_ROLE -> "PrincipalRole";
+      case PRINCIPAL_ROLE_ASSIGNMENT -> "PrincipalRoleAssignment";
+      case CATALOG -> "Catalog";
+      case CATALOG_ROLE -> "CatalogRole";
+      case CATALOG_ROLE_ASSIGNMENT -> "CatalogRoleAssignment";
+      case GRANT -> "Grant";
+      case NAMESPACE -> "Namespace";
+      case TABLE -> "Table";
+    };
+  }
+
+  /** Renders the accumulated counts and failures as a human-readable text block. */
+  public String render() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("=== Synchronization Report ===\n");
+
+    for (EntityType type : EntityType.values()) {
+      Map<SyncOutcome, Integer> outcomeCounts = counts.get(type);
+      int total =
+          outcomeCounts.get(SyncOutcome.CREATED)
+              + outcomeCounts.get(SyncOutcome.OVERWRITTEN)
+              + outcomeCounts.get(SyncOutcome.REMOVED)
+              + outcomeCounts.get(SyncOutcome.SKIPPED)
+              + outcomeCounts.get(SyncOutcome.FAILED);
+
+      if (total == 0) {
+        continue;
+      }
+
+      sb.append(
+          String.format(
+              "%-24s%d created, %d overwritten, %d removed, %d skipped, %d failed%n",
+              displayName(type) + ":",
+              outcomeCounts.get(SyncOutcome.CREATED),
+              outcomeCounts.get(SyncOutcome.OVERWRITTEN),
+              outcomeCounts.get(SyncOutcome.REMOVED),
+              outcomeCounts.get(SyncOutcome.SKIPPED),
+              outcomeCounts.get(SyncOutcome.FAILED)));
+    }
+
+    if (hasFailures()) {
+      sb.append("\nFailures:\n");
+      for (Failure failure : failures) {
+        sb.append(
+            String.format(
+                "  - %s '%s': %s%n",
+                displayName(failure.type()), failure.identifier(), failure.message()));
+      }
+    }
+
+    sb.append("===============================");
+
+    return sb.toString();
+  }
+}

--- a/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizerSkipIcebergContentTest.java
+++ b/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizerSkipIcebergContentTest.java
@@ -37,6 +37,7 @@ import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.tools.sync.polaris.catalog.NoOpETagManager;
 import org.apache.polaris.tools.sync.polaris.planning.NoOpSyncPlanner;
 import org.apache.polaris.tools.sync.polaris.planning.plan.SynchronizationPlan;
+import org.apache.polaris.tools.sync.polaris.planning.plan.SynchronizationReport;
 import org.apache.polaris.tools.sync.polaris.service.IcebergCatalogService;
 import org.apache.polaris.tools.sync.polaris.service.PolarisService;
 import org.junit.jupiter.api.Assertions;
@@ -299,6 +300,7 @@ public class PolarisSynchronizerSkipIcebergContentTest {
             target,
             new NoOpETagManager(),
             false,
+            new SynchronizationReport(),
             true);
 
     synchronizer.syncCatalogs();
@@ -323,6 +325,7 @@ public class PolarisSynchronizerSkipIcebergContentTest {
             target,
             new NoOpETagManager(),
             false,
+            new SynchronizationReport(),
             false);
 
     synchronizer.syncCatalogs();
@@ -354,6 +357,7 @@ public class PolarisSynchronizerSkipIcebergContentTest {
             target,
             new NoOpETagManager(),
             false,
+            new SynchronizationReport(),
             true);
 
     synchronizer.syncCatalogs();

--- a/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/planning/plan/SynchronizationReportTest.java
+++ b/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/planning/plan/SynchronizationReportTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.tools.sync.polaris.planning.plan;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SynchronizationReportTest {
+
+  @Test
+  public void recordSuccessIncrementsOnlyTargetedCell() {
+    SynchronizationReport report = new SynchronizationReport();
+
+    report.recordSuccess(EntityType.PRINCIPAL, SyncOutcome.CREATED);
+
+    String rendered = report.render();
+
+    Assertions.assertTrue(rendered.contains("Principal:"));
+    Assertions.assertTrue(rendered.contains("1 created, 0 overwritten, 0 removed, 0 skipped, 0 failed"));
+    Assertions.assertFalse(rendered.contains("Catalog:"));
+  }
+
+  @Test
+  public void recordFailureIncrementsFailedCountAndCapturesIdentifierAndMessage() {
+    SynchronizationReport report = new SynchronizationReport();
+
+    report.recordFailure(EntityType.TABLE, "db.orders", new RuntimeException("connection refused"));
+
+    String rendered = report.render();
+
+    Assertions.assertTrue(rendered.contains("Table:"));
+    Assertions.assertTrue(rendered.contains("0 created, 0 overwritten, 0 removed, 0 skipped, 1 failed"));
+    Assertions.assertTrue(rendered.contains("Table 'db.orders': connection refused"));
+  }
+
+  @Test
+  public void hasFailuresIsFalseForAnAllSuccessReport() {
+    SynchronizationReport report = new SynchronizationReport();
+
+    report.recordSuccess(EntityType.CATALOG, SyncOutcome.CREATED);
+    report.recordSuccess(EntityType.NAMESPACE, SyncOutcome.REMOVED);
+
+    Assertions.assertFalse(report.hasFailures());
+  }
+
+  @Test
+  public void hasFailuresIsTrueOnceAnyFailureIsRecorded() {
+    SynchronizationReport report = new SynchronizationReport();
+
+    report.recordSuccess(EntityType.CATALOG, SyncOutcome.CREATED);
+    report.recordFailure(EntityType.GRANT, "TABLE", new RuntimeException("boom"));
+
+    Assertions.assertTrue(report.hasFailures());
+  }
+
+  @Test
+  public void renderOmitsAllZeroEntityTypesAndFailuresSectionWhenEmpty() {
+    SynchronizationReport report = new SynchronizationReport();
+
+    report.recordSuccess(EntityType.PRINCIPAL_ROLE, SyncOutcome.CREATED);
+
+    String rendered = report.render();
+
+    Assertions.assertTrue(rendered.contains("PrincipalRole:"));
+    Assertions.assertFalse(rendered.contains("Grant:"));
+    Assertions.assertFalse(rendered.contains("Namespace:"));
+    Assertions.assertFalse(rendered.contains("Failures:"));
+  }
+
+  @Test
+  public void renderIncludesEachFailureWhenMultipleFailuresExist() {
+    SynchronizationReport report = new SynchronizationReport();
+
+    report.recordFailure(EntityType.PRINCIPAL, "alice", new RuntimeException("timeout"));
+    report.recordFailure(EntityType.TABLE, "db.returns", new RuntimeException("not found"));
+
+    String rendered = report.render();
+
+    Assertions.assertTrue(rendered.contains("Failures:"));
+    Assertions.assertTrue(rendered.contains("Principal 'alice': timeout"));
+    Assertions.assertTrue(rendered.contains("Table 'db.returns': not found"));
+  }
+
+  @Test
+  public void recordSuccessWithSkippedIncrementsSkippedCountAndDoesNotCountAsFailure() {
+    SynchronizationReport report = new SynchronizationReport();
+
+    report.recordSuccess(EntityType.NAMESPACE, SyncOutcome.SKIPPED);
+
+    String rendered = report.render();
+
+    Assertions.assertTrue(rendered.contains("Namespace:"));
+    Assertions.assertTrue(rendered.contains("0 created, 0 overwritten, 0 removed, 1 skipped, 0 failed"));
+    Assertions.assertFalse(report.hasFailures());
+  }
+}

--- a/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
+++ b/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
@@ -26,6 +26,7 @@ import org.apache.polaris.tools.sync.polaris.planning.CatalogNameFilterPlanner;
 import org.apache.polaris.tools.sync.polaris.planning.ModificationAwarePlanner;
 import org.apache.polaris.tools.sync.polaris.planning.BaseStrategyPlanner;
 import org.apache.polaris.tools.sync.polaris.planning.SynchronizationPlanner;
+import org.apache.polaris.tools.sync.polaris.planning.plan.SynchronizationReport;
 import org.apache.polaris.tools.sync.polaris.service.PolarisService;
 import org.apache.polaris.tools.sync.polaris.service.impl.PolarisApiService;
 import org.slf4j.Logger;
@@ -118,6 +119,13 @@ public class SyncPolarisCommand implements Callable<Integer> {
   )
   private BaseStrategyPlanner.Strategy strategy;
 
+  @CommandLine.Option(
+          names = {"--fail-on-error"},
+          description = "Exit with a non-zero status if any entity failed to synchronize, checked after the " +
+                  "synchronization run completes. Unlike --halt-on-failure, this does not stop the run early."
+  )
+  private boolean failOnError;
+
   @Override
   public Integer call() throws Exception {
     SynchronizationPlanner planner = SynchronizationPlanner.builder(new BaseStrategyPlanner(strategy))
@@ -125,6 +133,8 @@ public class SyncPolarisCommand implements Callable<Integer> {
             .conditionallyWrapBy(catalogNameRegex != null, p -> new CatalogNameFilterPlanner(catalogNameRegex, p))
             .wrapBy(AccessControlAwarePlanner::new)
             .build();
+
+    SynchronizationReport report = new SynchronizationReport();
 
     // auto generate omnipotent principals with write access on the target, read only access on source
     sourceProperties.put(PolarisApiService.ICEBERG_WRITE_ACCESS_PROPERTY, Boolean.toString(false));
@@ -145,7 +155,8 @@ public class SyncPolarisCommand implements Callable<Integer> {
                       source,
                       target,
                       etagManager,
-                      diffOnly);
+                      diffOnly,
+                      report);
       synchronizer.syncPrincipalRoles();
       if (shouldSyncPrincipals) {
         consoleLog.warn("Principal migration will reset credentials on the target Polaris instance. " +
@@ -155,6 +166,8 @@ public class SyncPolarisCommand implements Callable<Integer> {
       synchronizer.syncCatalogs();
     }
 
-    return 0;
+    consoleLog.info(report.render());
+
+    return (failOnError && report.hasFailures()) ? 1 : 0;
   }
 }

--- a/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
+++ b/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
@@ -163,7 +163,7 @@ public class SyncPolarisCommand implements Callable<Integer> {
                       target,
                       etagManager,
                       diffOnly,
-                      report);
+                      report,
                       skipIcebergContent);
       synchronizer.syncPrincipalRoles();
       if (shouldSyncPrincipals) {


### PR DESCRIPTION
## Motivation

  `PolarisSynchronizer` currently reports progress purely via interleaved SLF4J log lines (`clientLogger.info`/`.error`) scattered across each of its 9 sync methods. For any
  non-trivial migration — hundreds of catalogs, namespaces, or tables — this is unreadable: there's no way to tell at a glance what succeeded, what failed, or how many entities
  of each type were touched without grepping through thousands of log lines.
  
  This is especially painful for automated usage (CI, cron-based backup/sync jobs), where the only way to detect a partial failure today is to scrape logs for `ERROR` lines.
  There's also no way to fail a script/pipeline based on sync outcome — `sync-polaris` always exits `0`, even if individual entities failed to sync.

  Additionally, since the sync is designed to be idempotent (only the diff between source and target is applied), a fully-synced re-run currently logs each skipped entity
  individually but never surfaces a summary — so a user re-running the tool sees no output at all and can't easily tell "everything is already in sync" from "something silently
  didn't run."
  
  ## What this changes

  - `sync-polaris` now prints a **consolidated synchronization report** once, at the end of every run, instead of relying on interleaved logs. It summarizes, per entity type,
  how many entities were `created`, `overwritten`, `removed`, `skipped` (already in sync), and `failed`, followed by a list of failures with their identifiers and error
  messages:
  
```
    === Synchronization Report ===
    Principal:               3 created, 0 overwritten, 0 removed, 0 skipped, 1 failed
    Catalog:                 2 created, 1 overwritten, 0 removed, 5 skipped, 0 failed
    Table:                  20 created, 0 overwritten, 0 removed, 40 skipped, 2 failed

    Failures:
      - Principal 'alice': <exception message>
      - Table 'db.orders': <exception message>
    ===============================
```
  Entity types with all-zero counts are omitted to keep the report scannable, and the `Failures:` section is omitted entirely when there are none.

  - Adds a new `--fail-on-error` flag. By default, `sync-polaris` still exits `0` regardless of individual entity failures (preserving existing behavior: failures are logged
  and the run continues to completion). With `--fail-on-error`, the command exits non-zero if the report contains any failures. This is deliberately distinct from the existing
  `--halt-on-failure`, which stops the run at the *first* failure — `--fail-on-error` lets the run finish synchronizing everything it can, then fails afterward, which is
  generally what you want for a CI/cron job (best-effort sync, but still surface that something needs attention).

  - Entities that were already in sync are now tallied under `skipped` rather than just being logged and forgotten. Without this, an idempotent re-run against an already-synced
  target prints an empty report with no `===` content in between, which reads as ambiguous ("did it even check anything?") rather than reassuring.

  ## Implementation

  - New `EntityType`, `SyncOutcome`, and `SynchronizationReport` classes (`api/.../planning/plan/`), mirroring the existing `SynchronizationPlan`/`PlannedAction` pattern
  already used elsewhere in this module rather than introducing a new abstraction style.
  - `PolarisSynchronizer` takes a `SynchronizationReport` collaborator (constructor injection, same pattern as `etagManager`) and records an outcome at every
  create/overwrite/remove/skip site across all 9 sync methods.
  - `SyncPolarisCommand` constructs the report, passes it into `PolarisSynchronizer`, prints `report.render()` via the existing console logger after the run completes, and
  returns exit code `1` when `--fail-on-error` is set and `report.hasFailures()`.
  - README updated with a sample report and documentation for `--fail-on-error`.

  ## Test plan

  - [x] `SynchronizationReportTest`: `recordSuccess`/`recordFailure` target the correct cells, `hasFailures()` toggles correctly, `render()` omits all-zero entity types and the
  empty `Failures:` section, multiple failures render correctly, and `SKIPPED` is counted and rendered without being treated as a failure
  - [x] `./gradlew :polaris-synchronizer-api:test :polaris-synchronizer-cli:test` passes
  - [x] Manually verified end-to-end against a local docker-compose Polaris source/target setup: first sync shows correct `created` counts; a second, idempotent run shows
  `skipped` counts instead of an empty report

