### PR TITLE
Console: add kmsUnavailable option for S3 catalogs

### DIFF
--- a/console/spec/polaris-management-service.yml
+++ b/console/spec/polaris-management-service.yml
@@ -1135,10 +1135,15 @@ components:
               example: "https://s3.internal.example.com:1234"
             pathStyleAccess:
               type: boolean
-              description: >- 
+              description: >-
                 Whether S3 requests to files in this catalog should use 'path-style addressing for buckets'.
               example: true
               default: false
+            kmsUnavailable:
+              type: boolean
+              description: >-
+                if set to `true`, instructs Polaris Servers to avoid adding KMS key policies. This setting is
+                intended for configuring catalogs with S3-compatible storage implementations that do not support KMS.
 
     AzureStorageConfigInfo:
       type: object

--- a/console/src/components/forms/CreateCatalogModal.tsx
+++ b/console/src/components/forms/CreateCatalogModal.tsx
@@ -67,6 +67,7 @@ const schema = z
     s3_stsEndpoint: z.string().optional(),
     s3_stsUnavailable: z.boolean().optional(),
     s3_pathStyleAccess: z.boolean().optional(),
+    s3_kmsUnavailable: z.boolean().optional(),
 
     // Azure
     azure_tenantId: z.string().optional(),
@@ -170,6 +171,8 @@ export function CreateCatalogModal({ open, onOpenChange, onCreated }: CreateCata
           storageConfigInfo.stsUnavailable = values.s3_stsUnavailable
         if (typeof values.s3_pathStyleAccess === "boolean")
           storageConfigInfo.pathStyleAccess = values.s3_pathStyleAccess
+        if (typeof values.s3_kmsUnavailable === "boolean")
+          storageConfigInfo.kmsUnavailable = values.s3_kmsUnavailable
       }
       if (values.storageType === "AZURE") {
         if (values.azure_tenantId) storageConfigInfo.tenantId = values.azure_tenantId
@@ -391,6 +394,13 @@ export function CreateCatalogModal({ open, onOpenChange, onCreated }: CreateCata
                 </label>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Whether S3 requests should use path-style addressing for buckets.
+                </p>
+                <label className="flex items-center gap-2 text-sm">
+                  <input type="checkbox" {...register("s3_kmsUnavailable")} /> KMS unavailable
+                </label>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Indicates that Polaris should not use KMS (e.g. if KMS is not available). Use this
+                  for S3-compatible storage backends that do not support KMS.
                 </p>
               </div>
             </div>

--- a/console/src/components/forms/EditCatalogModal.tsx
+++ b/console/src/components/forms/EditCatalogModal.tsx
@@ -61,6 +61,7 @@ const schema = z
     s3_stsEndpoint: z.string().optional(),
     s3_stsUnavailable: z.boolean().optional(),
     s3_pathStyleAccess: z.boolean().optional(),
+    s3_kmsUnavailable: z.boolean().optional(),
 
     // Azure
     azure_tenantId: z.string().optional(),
@@ -141,6 +142,8 @@ export function EditCatalogModal({
           storageConfigInfo.stsUnavailable = values.s3_stsUnavailable
         if (typeof values.s3_pathStyleAccess === "boolean")
           storageConfigInfo.pathStyleAccess = values.s3_pathStyleAccess
+        if (typeof values.s3_kmsUnavailable === "boolean")
+          storageConfigInfo.kmsUnavailable = values.s3_kmsUnavailable
       }
       if (values.storageType === "AZURE") {
         if (values.azure_tenantId) storageConfigInfo.tenantId = values.azure_tenantId
@@ -217,6 +220,7 @@ export function EditCatalogModal({
         s3_stsEndpoint: storageConfig?.stsEndpoint || "",
         s3_stsUnavailable: storageConfig?.stsUnavailable || false,
         s3_pathStyleAccess: storageConfig?.pathStyleAccess || false,
+        s3_kmsUnavailable: storageConfig?.kmsUnavailable || false,
         azure_tenantId: storageConfig?.tenantId || "",
         azure_multiTenantAppName: storageConfig?.multiTenantAppName || "",
         azure_consentUrl: storageConfig?.consentUrl || "",
@@ -341,6 +345,13 @@ export function EditCatalogModal({
                 </label>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Whether S3 requests should use path-style addressing for buckets.
+                </p>
+                <label className="flex items-center gap-2 text-sm">
+                  <input type="checkbox" {...register("s3_kmsUnavailable")} /> KMS unavailable
+                </label>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Indicates that Polaris should not use KMS (e.g. if KMS is not available). Use this
+                  for S3-compatible storage backends that do not support KMS.
                 </p>
               </div>
             </div>

--- a/console/src/pages/CatalogDetails.tsx
+++ b/console/src/pages/CatalogDetails.tsx
@@ -226,6 +226,14 @@ export function CatalogDetails() {
                             </span>
                           </div>
                         )}
+                        {catalog.storageConfigInfo.kmsUnavailable && (
+                          <div className="flex gap-2">
+                            <span className="font-mono text-sm text-muted-foreground">
+                              KMS Unavailable:
+                            </span>
+                            <span className="font-mono text-sm">true</span>
+                          </div>
+                        )}
                       </div>
                     )}
                     {catalog.storageConfigInfo.storageType === "AZURE" && (

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -32,6 +32,7 @@ export interface StorageConfigInfo {
   stsEndpoint?: string
   stsUnavailable?: boolean
   pathStyleAccess?: boolean
+  kmsUnavailable?: boolean
   // Azure-specific
   tenantId?: string
   multiTenantAppName?: string


### PR DESCRIPTION
## Summary
- Adds the `kmsUnavailable` field (already supported by the Polaris REST API's `AwsStorageConfigInfo`, added upstream in apache/polaris#3501 and exposed via the CLI's `--no-kms` flag on `catalogs create`) to the console's `StorageConfigInfo` type, the create/edit catalog forms, the details view, and the checked-in OpenAPI spec.
- Lets console users mark an S3 (or S3-compatible: MinIO, Ceph RGW, VAST, etc.) catalog as not supporting KMS, so Polaris skips adding wildcard KMS IAM policy statements when vending scoped credentials.
- Mirrors the existing `stsUnavailable`/`pathStyleAccess` boolean field pattern already used in both catalog modals.

## Changes
- `console/src/types/api.ts`: add `kmsUnavailable?: boolean` to `StorageConfigInfo`
- `console/spec/polaris-management-service.yml`: add `kmsUnavailable` to `AwsStorageConfigInfo`, matching the upstream Polaris spec wording
- `console/src/components/forms/CreateCatalogModal.tsx` / `EditCatalogModal.tsx`: add the `s3_kmsUnavailable` form field, checkbox UI, and payload wiring
- `console/src/pages/CatalogDetails.tsx`: display `KMS Unavailable: true` in the S3 storage config section when set

## Test plan
- [x] `npm run lint` passes with no warnings/errors
- [x] `npx tsc -b --noEmit` passes with no errors
- [ ] Manual click-through in a running console against a live Polaris backend