### PR TITLE
Synchronizer: Add --skip-catalog-sync flag for DR-oriented syncs

### DIFF
--- a/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
+++ b/polaris-synchronizer/api/src/main/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizer.java
@@ -68,6 +68,7 @@ public class PolarisSynchronizer {
 
   private final SynchronizationReport report;
   private final boolean skipIcebergContent;
+  private final boolean skipCatalogSync;
 
   public PolarisSynchronizer(
       Logger clientLogger,
@@ -78,7 +79,8 @@ public class PolarisSynchronizer {
       ETagManager etagManager,
       boolean diffOnly,
       SynchronizationReport report,
-      boolean skipIcebergContent) {
+      boolean skipIcebergContent,
+      boolean skipCatalogSync) {
     this.clientLogger =
         clientLogger == null ? LoggerFactory.getLogger(PolarisSynchronizer.class) : clientLogger;
     this.haltOnFailure = haltOnFailure;
@@ -89,6 +91,7 @@ public class PolarisSynchronizer {
     this.diffOnly = diffOnly;
     this.report = report;
     this.skipIcebergContent = skipIcebergContent;
+    this.skipCatalogSync = skipCatalogSync;
   }
 
   /**
@@ -632,7 +635,19 @@ public class PolarisSynchronizer {
     int syncsCompleted = 0;
     int totalSyncsToComplete = totalSyncsToComplete(catalogSyncPlan);
 
+    Set<String> catalogNamesSkippedFromChildSync = new HashSet<>();
+
     for (Catalog catalog : catalogSyncPlan.entitiesToCreate()) {
+      if (skipCatalogSync) {
+        clientLogger.warn(
+            "Skipping creation of catalog {} because catalog synchronization is disabled. It does "
+                + "not exist on the target, so its catalog-roles and grants will not be synced either.",
+            catalog.getName());
+        report.recordSuccess(EntityType.CATALOG, SyncOutcome.SKIPPED);
+        catalogNamesSkippedFromChildSync.add(catalog.getName());
+        continue;
+      }
+
       try {
         target.createCatalog(catalog);
         clientLogger.info(
@@ -654,6 +669,15 @@ public class PolarisSynchronizer {
     }
 
     for (Catalog catalog : catalogSyncPlan.entitiesToOverwrite()) {
+      if (skipCatalogSync) {
+        clientLogger.info(
+            "Skipping overwrite of catalog {} because catalog synchronization is disabled. "
+                + "Catalog-roles and grants will still be synced against the existing target catalog.",
+            catalog.getName());
+        report.recordSuccess(EntityType.CATALOG, SyncOutcome.SKIPPED);
+        continue;
+      }
+
       try {
         target.dropCatalogCascade(catalog.getName());
         target.createCatalog(catalog);
@@ -676,6 +700,14 @@ public class PolarisSynchronizer {
     }
 
     for (Catalog catalog : catalogSyncPlan.entitiesToRemove()) {
+      if (skipCatalogSync) {
+        clientLogger.info(
+            "Skipping removal of catalog {} because catalog synchronization is disabled.",
+            catalog.getName());
+        report.recordSuccess(EntityType.CATALOG, SyncOutcome.SKIPPED);
+        continue;
+      }
+
       try {
         target.dropCatalogCascade(catalog.getName());
         clientLogger.info(
@@ -697,6 +729,9 @@ public class PolarisSynchronizer {
     }
 
     for (Catalog catalog : catalogSyncPlan.entitiesToSyncChildren()) {
+      if (catalogNamesSkippedFromChildSync.contains(catalog.getName())) {
+        continue;
+      }
 
       if (skipIcebergContent) {
         clientLogger.info(

--- a/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizerSkipCatalogSyncTest.java
+++ b/polaris-synchronizer/api/src/test/java/org/apache/polaris/tools/sync/polaris/PolarisSynchronizerSkipCatalogSyncTest.java
@@ -44,37 +44,48 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that {@code --skip-iceberg-content} prevents {@link PolarisSynchronizer#syncCatalogs()}
- * from ever initializing an Iceberg REST catalog session, while still synchronizing catalog roles.
+ * Verifies that {@code --skip-catalog-sync} prevents {@link PolarisSynchronizer#syncCatalogs()}
+ * from creating, overwriting, or removing catalog objects on the target, while still synchronizing
+ * catalog-roles/grants for catalogs that already exist on the target.
  */
-public class PolarisSynchronizerSkipIcebergContentTest {
+public class PolarisSynchronizerSkipCatalogSyncTest {
 
-  private static final Catalog catalog =
-      new PolarisCatalog()
-          .name("catalog")
-          .type(Catalog.TypeEnum.INTERNAL)
-          .properties(new CatalogProperties())
-          .storageConfigInfo(
-              new AwsStorageConfigInfo()
-                  .storageType(StorageConfigInfo.StorageTypeEnum.S3)
-                  .roleArn("roleArn")
-                  .userArn("userArn")
-                  .externalId("externalId")
-                  .region("region"));
+  private static Catalog newCatalog(String name) {
+    return new PolarisCatalog()
+        .name(name)
+        .type(Catalog.TypeEnum.INTERNAL)
+        .properties(new CatalogProperties())
+        .storageConfigInfo(
+            new AwsStorageConfigInfo()
+                .storageType(StorageConfigInfo.StorageTypeEnum.S3)
+                .roleArn("roleArn")
+                .userArn("userArn")
+                .externalId("externalId")
+                .region("region"));
+  }
 
-  private static final CatalogRole catalogRole = new CatalogRole().name("catalog-role");
+  private static final Catalog sourceOnlyCatalog = newCatalog("source-only-catalog");
+  private static final Catalog overwriteCatalog = newCatalog("overwrite-catalog");
+  private static final Catalog removeCatalog = newCatalog("remove-catalog");
 
-  private static final GrantResource tableScopedGrant =
-      new GrantResource().type(GrantResource.TypeEnum.TABLE);
-
-  /** Planner that always presents {@link #catalog} as needing its children synced. */
-  private static class SingleCatalogPlanner extends NoOpSyncPlanner {
+  /** Planner that stages one catalog for CREATE, one for OVERWRITE, and one for REMOVE. */
+  private static class CreateOverwriteRemovePlanner extends NoOpSyncPlanner {
     @Override
     public SynchronizationPlan<Catalog> planCatalogSync(
         List<Catalog> catalogsOnSource, List<Catalog> catalogsOnTarget) {
       SynchronizationPlan<Catalog> plan = new SynchronizationPlan<>();
-      plan.skipEntity(catalog);
+      plan.createEntity(sourceOnlyCatalog);
+      plan.overwriteEntity(overwriteCatalog);
+      plan.removeEntity(removeCatalog);
       return plan;
+    }
+
+    @Override
+    public SynchronizationPlan<CatalogRole> planCatalogRoleSync(
+        String catalogName,
+        List<CatalogRole> catalogRolesOnSource,
+        List<CatalogRole> catalogRolesOnTarget) {
+      return new SynchronizationPlan<>();
     }
 
     @Override
@@ -85,34 +96,6 @@ public class PolarisSynchronizerSkipIcebergContentTest {
         List<Namespace> namespacesOnTarget) {
       // NoOpSyncPlanner returns null here, which would NPE once syncNamespaces() runs.
       return new SynchronizationPlan<>();
-    }
-  }
-
-  /**
-   * Planner that, in addition to {@link SingleCatalogPlanner}'s behavior, always presents
-   * {@link #catalogRole} as needing its children synced and always stages {@link #tableScopedGrant}
-   * for creation - regardless of whether the underlying table was ever synced.
-   */
-  private static class SingleCatalogWithGrantPlanner extends SingleCatalogPlanner {
-    @Override
-    public SynchronizationPlan<CatalogRole> planCatalogRoleSync(
-        String catalogName,
-        List<CatalogRole> catalogRolesOnSource,
-        List<CatalogRole> catalogRolesOnTarget) {
-      SynchronizationPlan<CatalogRole> plan = new SynchronizationPlan<>();
-      plan.skipEntity(catalogRole);
-      return plan;
-    }
-
-    @Override
-    public SynchronizationPlan<GrantResource> planGrantSync(
-        String catalogName,
-        String catalogRoleName,
-        List<GrantResource> grantsOnSource,
-        List<GrantResource> grantsOnTarget) {
-      SynchronizationPlan<GrantResource> plan = new SynchronizationPlan<>();
-      plan.createEntity(tableScopedGrant);
-      return plan;
     }
   }
 
@@ -156,13 +139,13 @@ public class PolarisSynchronizerSkipIcebergContentTest {
     public void close() {}
   }
 
-  /** Stub {@link PolarisService} that tracks how often Iceberg and catalog-role sync is attempted. */
+  /** Stub {@link PolarisService} that tracks catalog create/overwrite/remove and catalog-role sync calls. */
   private static class TrackingPolarisService implements PolarisService {
 
     private final List<Catalog> catalogs;
-    final List<GrantResource> grantsAdded = new ArrayList<>();
-    int initializeIcebergCatalogServiceCalls = 0;
-    int listCatalogRolesCalls = 0;
+    final List<String> catalogsCreated = new ArrayList<>();
+    final List<String> catalogsDropped = new ArrayList<>();
+    final List<String> catalogRoleSyncsAttempted = new ArrayList<>();
 
     TrackingPolarisService(List<Catalog> catalogs) {
       this.catalogs = catalogs;
@@ -227,14 +210,18 @@ public class PolarisSynchronizerSkipIcebergContentTest {
     }
 
     @Override
-    public void createCatalog(Catalog catalog) {}
+    public void createCatalog(Catalog catalog) {
+      catalogsCreated.add(catalog.getName());
+    }
 
     @Override
-    public void dropCatalogCascade(String catalogName) {}
+    public void dropCatalogCascade(String catalogName) {
+      catalogsDropped.add(catalogName);
+    }
 
     @Override
     public List<CatalogRole> listCatalogRoles(String catalogName) {
-      listCatalogRolesCalls++;
+      catalogRoleSyncsAttempted.add(catalogName);
       return List.of();
     }
 
@@ -269,16 +256,13 @@ public class PolarisSynchronizerSkipIcebergContentTest {
     }
 
     @Override
-    public void addGrant(String catalogName, String catalogRoleName, GrantResource grant) {
-      grantsAdded.add(grant);
-    }
+    public void addGrant(String catalogName, String catalogRoleName, GrantResource grant) {}
 
     @Override
     public void revokeGrant(String catalogName, String catalogRoleName, GrantResource grant) {}
 
     @Override
     public IcebergCatalogService initializeIcebergCatalogService(String catalogName) {
-      initializeIcebergCatalogServiceCalls++;
       return new CountingIcebergCatalogService();
     }
 
@@ -287,86 +271,65 @@ public class PolarisSynchronizerSkipIcebergContentTest {
   }
 
   @Test
-  public void testSkipIcebergContentSkipsIcebergSyncButStillSyncsCatalogRoles() {
-    TrackingPolarisService source = new TrackingPolarisService(List.of(catalog));
-    TrackingPolarisService target = new TrackingPolarisService(List.of());
+  public void testSkipCatalogSyncSkipsCreateOverwriteAndRemoveButStillSyncsRolesForExistingCatalogs() {
+    TrackingPolarisService source =
+        new TrackingPolarisService(List.of(sourceOnlyCatalog, overwriteCatalog));
+    TrackingPolarisService target = new TrackingPolarisService(List.of(overwriteCatalog, removeCatalog));
 
     PolarisSynchronizer synchronizer =
         new PolarisSynchronizer(
             null,
             false,
-            new SingleCatalogPlanner(),
+            new CreateOverwriteRemovePlanner(),
             source,
             target,
             new NoOpETagManager(),
             false,
             new SynchronizationReport(),
-            true,
-            false);
+            true /* skipIcebergContent */,
+            true /* skipCatalogSync */);
 
     synchronizer.syncCatalogs();
 
-    Assertions.assertEquals(0, source.initializeIcebergCatalogServiceCalls);
-    Assertions.assertEquals(0, target.initializeIcebergCatalogServiceCalls);
-    Assertions.assertEquals(1, source.listCatalogRolesCalls);
-    Assertions.assertEquals(1, target.listCatalogRolesCalls);
+    // no catalog objects should be created, overwritten (dropped+recreated), or removed on target
+    Assertions.assertEquals(List.of(), target.catalogsCreated);
+    Assertions.assertEquals(List.of(), target.catalogsDropped);
+
+    // the source-only catalog has no match on target, so it must be excluded from catalog-role sync
+    Assertions.assertFalse(
+        target.catalogRoleSyncsAttempted.contains(sourceOnlyCatalog.getName()));
+
+    // the catalog that exists on both sides should still have its catalog-roles synced
+    Assertions.assertTrue(target.catalogRoleSyncsAttempted.contains(overwriteCatalog.getName()));
+    Assertions.assertTrue(source.catalogRoleSyncsAttempted.contains(overwriteCatalog.getName()));
   }
 
   @Test
-  public void testIcebergContentSyncedWhenNotSkipped() {
-    TrackingPolarisService source = new TrackingPolarisService(List.of(catalog));
-    TrackingPolarisService target = new TrackingPolarisService(List.of());
+  public void testCatalogSyncedWhenNotSkipped() {
+    TrackingPolarisService source =
+        new TrackingPolarisService(List.of(sourceOnlyCatalog, overwriteCatalog));
+    TrackingPolarisService target = new TrackingPolarisService(List.of(overwriteCatalog, removeCatalog));
 
     PolarisSynchronizer synchronizer =
         new PolarisSynchronizer(
             null,
             false,
-            new SingleCatalogPlanner(),
+            new CreateOverwriteRemovePlanner(),
             source,
             target,
             new NoOpETagManager(),
             false,
             new SynchronizationReport(),
-            false,
-            false);
+            true /* skipIcebergContent */,
+            false /* skipCatalogSync */);
 
     synchronizer.syncCatalogs();
 
-    Assertions.assertEquals(1, source.initializeIcebergCatalogServiceCalls);
-    Assertions.assertEquals(1, target.initializeIcebergCatalogServiceCalls);
-    Assertions.assertEquals(1, source.listCatalogRolesCalls);
-    Assertions.assertEquals(1, target.listCatalogRolesCalls);
-  }
-
-  /**
-   * Documents a known consequence of {@code --skip-iceberg-content}: grant sync is not scoped by
-   * grant type, so a TABLE- or NAMESPACE-scoped grant is still applied to the target even though the
-   * table/namespace it refers to was never synced. Against a real Polaris server this would likely
-   * fail server-side (grant referencing an unknown resource); this test only proves the client still
-   * attempts it.
-   */
-  @Test
-  public void testTableScopedGrantsStillAttemptedWhenIcebergContentSkipped() {
-    TrackingPolarisService source = new TrackingPolarisService(List.of(catalog));
-    TrackingPolarisService target = new TrackingPolarisService(List.of());
-
-    PolarisSynchronizer synchronizer =
-        new PolarisSynchronizer(
-            null,
-            false,
-            new SingleCatalogWithGrantPlanner(),
-            source,
-            target,
-            new NoOpETagManager(),
-            false,
-            new SynchronizationReport(),
-            true,
-            false);
-
-    synchronizer.syncCatalogs();
-
-    Assertions.assertEquals(0, source.initializeIcebergCatalogServiceCalls);
-    Assertions.assertEquals(0, target.initializeIcebergCatalogServiceCalls);
-    Assertions.assertEquals(List.of(tableScopedGrant), target.grantsAdded);
+    Assertions.assertEquals(
+        List.of(sourceOnlyCatalog.getName(), overwriteCatalog.getName()), target.catalogsCreated);
+    Assertions.assertEquals(
+        List.of(overwriteCatalog.getName(), removeCatalog.getName()), target.catalogsDropped);
+    Assertions.assertTrue(target.catalogRoleSyncsAttempted.contains(sourceOnlyCatalog.getName()));
+    Assertions.assertTrue(target.catalogRoleSyncsAttempted.contains(overwriteCatalog.getName()));
   }
 }

--- a/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
+++ b/polaris-synchronizer/cli/src/main/java/org/apache/polaris/tools/sync/polaris/SyncPolarisCommand.java
@@ -113,6 +113,16 @@ public class SyncPolarisCommand implements Callable<Integer> {
   private boolean skipIcebergContent;
 
   @CommandLine.Option(
+          names = {"--skip-catalog-sync"},
+          description = "Skip creation, overwrite, and removal of catalogs themselves. Catalog-roles and grants " +
+                  "will still be synchronized for catalogs that already exist on the target. Catalogs that only " +
+                  "exist on the source will be skipped entirely, since there is no matching catalog on the target " +
+                  "to synchronize catalog-roles and grants against. Useful for disaster-recovery setups where " +
+                  "target catalogs are pre-created with different storage locations than the source."
+  )
+  private boolean skipCatalogSync;
+
+  @CommandLine.Option(
           names = {"--strategy"},
           defaultValue = "CREATE_ONLY",
           description = "The synchronization strategy to use. Options: " +
@@ -164,7 +174,8 @@ public class SyncPolarisCommand implements Callable<Integer> {
                       etagManager,
                       diffOnly,
                       report,
-                      skipIcebergContent);
+                      skipIcebergContent,
+                      skipCatalogSync);
       synchronizer.syncPrincipalRoles();
       if (shouldSyncPrincipals) {
         consoleLog.warn("Principal migration will reset credentials on the target Polaris instance. " +


### PR DESCRIPTION
### Summary
  
  Adds a `--skip-catalog-sync` flag to `sync-polaris` that skips creation, overwrite, and removal of catalog objects on the target, while still synchronizing catalog-roles and
  grants for catalogs that already exist there.

  This complements the existing `--skip-iceberg-content` flag (added in #256) and is aimed at the same class of problem: disaster-recovery setups where the synchronizer
  shouldn't be allowed to mutate certain top-level resources on the target.

  ### Motivation

  In a DR setup, target catalogs are often pre-created with intentionally different storage locations (`allowedLocations`, `default-base-location`, `roleArn`, etc.) than the
  source. Today, if a catalog exists on both source and target and the synchronization strategy is `CREATE_AND_OVERWRITE` or `REPLICATE` (or `--diff-only` detects a
  difference), the synchronizer will `dropCatalogCascade` + `createCatalog` on the target, copying the source catalog's storage config verbatim and silently clobbering the
  DR-specific location.

  `--skip-catalog-sync` lets operators keep principal, principal-role, catalog-role, and grant synchronization fully active while guaranteeing catalog objects themselves are
  never created, overwritten, or removed on the target.

  ### Changes

  - `PolarisSynchronizer`: new `skipCatalogSync` constructor parameter/field. `syncCatalogs()` now checks this flag before each of the create/overwrite/remove operations.
  - `SyncPolarisCommand`: new `--skip-catalog-sync` CLI option, wired into the `PolarisSynchronizer` constructor call.

  ### Behavior when --skip-catalog-sync is set

  - Catalogs that only exist on the source (would be created): skipped entirely, with a warning logged. Since no matching catalog exists on the target, there is nothing to
  synchronize catalog-roles/grants against, so these are also excluded from catalog-role sync for that catalog.
  - Catalogs that exist on both source and target (would be overwritten): the catalog object itself (drop + recreate) is skipped, but catalog-roles and grants are still
  synchronized against the existing target catalog.
  - Catalogs that would be removed (target-only, under the REPLICATE strategy): removal is skipped, and the target catalog is left untouched.

  Iceberg namespace/table sync is governed independently by `--skip-iceberg-content`, so the two flags can be combined to synchronize only principals, principal-roles,
  catalog-roles, and grants, without ever touching catalog objects or Iceberg content on the target.

  ### Backward compatibility

  `--skip-catalog-sync` defaults to `false`. No behavior changes for existing invocations unless the flag is explicitly passed.

  ### Testing
  
  Added `PolarisSynchronizerSkipCatalogSyncTest`, covering the skipped case (create/overwrite/remove all skipped on the target, source-only catalogs excluded from catalog-role
  sync, catalogs existing on both sides still get catalog-role sync) and the non-skipped case (existing behavior unchanged). Updated `PolarisSynchronizerSkipIcebergContentTest`
  call sites for the new constructor parameter; all existing tests continue to pass.

