### PR TITLE
Catalog Migrator: Add Iceberg view migration support

### DIFF
--- a/iceberg-catalog-migrator/README.md
+++ b/iceberg-catalog-migrator/README.md
@@ -19,10 +19,10 @@
 
 # Iceberg Catalog Migrator
  
-The Iceberg Catalog Migrator is a command-line tool that enables bulk migration of [Apache Iceberg](https://iceberg.apache.org/) tables from one [Iceberg Catalog](https://iceberg.apache.org/rest-catalog-spec/) to another without the need to copy the data. This tool works with all Iceberg Catalogs; not just Polaris.
+The Iceberg Catalog Migrator is a command-line tool that enables bulk migration of [Apache Iceberg](https://iceberg.apache.org/) tables and views from one [Iceberg Catalog](https://iceberg.apache.org/rest-catalog-spec/) to another without the need to copy the data. This tool works with all Iceberg Catalogs; not just Polaris.
 
 The migrator tool provides two operations:
-* Migrate - Bulk migration of the Iceberg tables from source catalog to target catalog. Table entries from source catalog will be deleted after the successful migration to the target catalog.
+* Migrate - Bulk migration of the Iceberg tables and views from source catalog to target catalog. Table and view entries from source catalog will be deleted after the successful migration to the target catalog.
 * Register - Bulk register the Iceberg tables from source catalog to target catalog. 
 
 > :warning: `register` command just registers the table.
@@ -31,9 +31,12 @@ Which means the table will be present in both the catalogs after registering.
 It is recommended to use the 'migrate' command in CLI to automatically delete the table from source catalog after registering
 or avoid operating tables from the source catalog after registering if 'migrate' command is not used.**
 
-> :warning: **Avoid using this tool when there are in-progress commits for tables in the source catalog 
+> :warning: **Avoid using this tool when there are in-progress commits for tables or views in the source catalog
 to prevent missing updates, data loss and table corruption in the target catalog. 
 In-progress commits may not be properly transferred and could compromise the integrity of your data.**
+
+Views are migrated only by the `migrate` command. The `register` command remains table-only because
+Iceberg view deletion does not expose a purge-false mode equivalent to table migration.
 
 Please use the [getting started guide](docs/getting-started.md) for a step-by-step guide on how to use the tool.
 

--- a/iceberg-catalog-migrator/api-test/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/test/AbstractTest.java
+++ b/iceberg-catalog-migrator/api-test/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/test/AbstractTest.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterAll;
@@ -46,6 +47,10 @@ public abstract class AbstractTest {
   public static final TableIdentifier FOO_TBL2 = TableIdentifier.of(FOO, "tbl2");
   public static final TableIdentifier BAR_TBL3 = TableIdentifier.of(BAR, "tbl3");
   public static final TableIdentifier BAR_TBL4 = TableIdentifier.of(BAR, "tbl4");
+
+  public static final TableIdentifier FOO_VIEW1 = TableIdentifier.of(FOO, "view1");
+  public static final TableIdentifier FOO_VIEW2 = TableIdentifier.of(FOO, "view2");
+  public static final TableIdentifier BAR_VIEW3 = TableIdentifier.of(BAR, "view3");
 
   private static final List<Namespace> defaultNamespaceList = Arrays.asList(FOO, BAR, DB1);
 
@@ -108,13 +113,18 @@ public abstract class AbstractTest {
   }
 
   protected static void dropNamespaces() {
-    Stream.of(sourceCatalog, targetCatalog)
-        .map(catalog -> (SupportsNamespaces) catalog)
-        .forEach(
-            catalog ->
-                defaultNamespaceList.stream()
-                    .filter(catalog::namespaceExists)
-                    .forEach(catalog::dropNamespace));
+    Stream.of(sourceCatalog, targetCatalog).forEach(AbstractTest::dropNamespaces);
+  }
+
+  protected static void dropSourceNamespaces() {
+    dropNamespaces(sourceCatalog);
+  }
+
+  private static void dropNamespaces(Catalog catalog) {
+    SupportsNamespaces namespaces = (SupportsNamespaces) catalog;
+    defaultNamespaceList.stream()
+        .filter(namespaces::namespaceExists)
+        .forEach(namespaces::dropNamespace);
   }
 
   protected static void createTables() {
@@ -126,14 +136,70 @@ public abstract class AbstractTest {
     sourceCatalog.createTable(BAR_TBL4, schema);
   }
 
+  protected static void createView() {
+    createView(FOO_VIEW1, "select * from foo.tbl1");
+  }
+
+  protected static void createViews() {
+    createView(FOO_VIEW2, "select * from foo.tbl2");
+    createView(BAR_VIEW3, "select * from bar.tbl3");
+  }
+
+  protected static void createView(TableIdentifier identifier, String sql) {
+    if (sourceCatalog instanceof ViewCatalog viewCatalog) {
+      SupportsNamespaces namespaces = (SupportsNamespaces) sourceCatalog;
+      if (!namespaces.namespaceExists(identifier.namespace())) {
+        namespaces.createNamespace(identifier.namespace());
+      }
+      viewCatalog
+          .buildView(identifier)
+          .withSchema(schema)
+          .withDefaultNamespace(identifier.namespace())
+          .withDefaultCatalog(sourceCatalog.name())
+          .withQuery("spark", sql)
+          .withProperty("prop1", "val1")
+          .create();
+    }
+  }
+
   protected static void dropTables() {
-    Stream.of(sourceCatalog, targetCatalog)
+    dropTables(targetCatalog, false);
+    dropTables(sourceCatalog, true);
+  }
+
+  private static void dropTables(Catalog catalog, boolean purge) {
+    defaultNamespaceList.stream()
+        .filter(namespace -> ((SupportsNamespaces) catalog).namespaceExists(namespace))
         .forEach(
-            catalog ->
-                defaultNamespaceList.stream()
-                    .filter(namespace -> ((SupportsNamespaces) catalog).namespaceExists(namespace))
-                    .forEach(
-                        namespace -> catalog.listTables(namespace).forEach(catalog::dropTable)));
+            namespace ->
+                catalog
+                    .listTables(namespace)
+                    .forEach(identifier -> catalog.dropTable(identifier, purge)));
+  }
+
+  protected static void dropViews() {
+    dropViews(targetCatalog);
+    dropViews(sourceCatalog);
+  }
+
+  private static void dropViews(Catalog catalog) {
+    if (catalog instanceof ViewCatalog viewCatalog) {
+      defaultNamespaceList.stream()
+          .filter(namespace -> ((SupportsNamespaces) catalog).namespaceExists(namespace))
+          .forEach(
+              namespace ->
+                  viewCatalog
+                      .listViews(namespace)
+                      .forEach(identifier -> dropViewIfPresent(viewCatalog, identifier)));
+    }
+  }
+
+  private static void dropViewIfPresent(ViewCatalog viewCatalog, TableIdentifier identifier) {
+    try {
+      viewCatalog.dropView(identifier);
+    } catch (RuntimeException e) {
+      // Best-effort cleanup between tests.
+    }
   }
 
   protected static Map<String, String> nessieCatalogProperties(boolean isSourceCatalog) {

--- a/iceberg-catalog-migrator/api/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/CatalogMigrationResult.java
+++ b/iceberg-catalog-migrator/api/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/CatalogMigrationResult.java
@@ -30,4 +30,10 @@ public interface CatalogMigrationResult {
   List<TableIdentifier> failedToRegisterTableIdentifiers();
 
   List<TableIdentifier> failedToDeleteTableIdentifiers();
+
+  List<TableIdentifier> registeredViewIdentifiers();
+
+  List<TableIdentifier> failedToRegisterViewIdentifiers();
+
+  List<TableIdentifier> failedToDeleteViewIdentifiers();
 }

--- a/iceberg-catalog-migrator/api/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/CatalogMigrator.java
+++ b/iceberg-catalog-migrator/api/src/main/java/org/apache/polaris/iceberg/catalog/migrator/api/CatalogMigrator.java
@@ -34,9 +34,12 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.view.BaseView;
+import org.apache.iceberg.view.ViewOperations;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +137,55 @@ public abstract class CatalogMigrator {
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
+  public Set<TableIdentifier> getMatchingViewIdentifiers(String identifierRegex) {
+    LOG.info("Collecting all the namespaces from source catalog...");
+    Set<Namespace> namespaces = new LinkedHashSet<>();
+    getAllNamespacesFromSourceCatalog(Namespace.empty(), namespaces);
+
+    return getMatchingViewIdentifiers(identifierRegex, namespaces);
+  }
+
+  private Set<TableIdentifier> getMatchingViewIdentifiers(
+      String identifierRegex, Set<Namespace> namespaces) {
+
+    if (!(sourceCatalog() instanceof ViewCatalog)) {
+      return new LinkedHashSet<>();
+    }
+
+    Predicate<TableIdentifier> matchedIdentifiersPredicate;
+    if (identifierRegex == null) {
+      LOG.info("Collecting all the views from all the namespaces of source catalog...");
+      matchedIdentifiersPredicate = tableIdentifier -> true;
+    } else {
+      LOG.info(
+          "Collecting all the views from all the namespaces of source catalog"
+              + " which matches the regex pattern:{}",
+          identifierRegex);
+      Pattern pattern = Pattern.compile(identifierRegex);
+      matchedIdentifiersPredicate =
+          tableIdentifier -> pattern.matcher(tableIdentifier.toString()).matches();
+    }
+    return namespaces.stream()
+        .flatMap(
+            namespace -> {
+              try {
+                return ((ViewCatalog) sourceCatalog())
+                    .listViews(namespace).stream().filter(matchedIdentifiersPredicate);
+              } catch (IllegalArgumentException | NoSuchNamespaceException exception) {
+                if (namespace.isEmpty()) {
+                  // some catalogs don't support empty namespace.
+                  // Hence, just log the warning and ignore the exception.
+                  LOG.warn(
+                      "Failed to identify views from empty namespace : {}", exception.getMessage());
+                  return Stream.empty();
+                } else {
+                  throw exception;
+                }
+              }
+            })
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
   /**
    * Register or Migrate a single table from one catalog(source catalog) to another catalog(target
    * catalog).
@@ -167,6 +219,41 @@ public abstract class CatalogMigrator {
       } else {
         LOG.error(
             "Failed to delete the table after migration {} : {}",
+            identifier,
+            exception.getMessage());
+      }
+    }
+    return this;
+  }
+
+  public CatalogMigrator migrateView(TableIdentifier identifier) {
+    Preconditions.checkArgument(identifier != null, "Identifier is null");
+    Preconditions.checkState(
+        deleteEntriesFromSourceCatalog(),
+        "Registering views is unsupported. Use migrate to migrate views.");
+    Preconditions.checkState(
+        sourceCatalog() instanceof ViewCatalog, "source catalog doesn't support views");
+    Preconditions.checkState(
+        targetCatalog() instanceof ViewCatalog, "target catalog doesn't support views");
+
+    boolean isRegistered = registerViewToTargetCatalog(identifier);
+    if (isRegistered) {
+      resultBuilder.addRegisteredViewIdentifiers(identifier);
+    } else {
+      resultBuilder.addFailedToRegisterViewIdentifiers(identifier);
+    }
+
+    try {
+      if (isRegistered && !((ViewCatalog) sourceCatalog()).dropView(identifier)) {
+        resultBuilder.addFailedToDeleteViewIdentifiers(identifier);
+      }
+    } catch (Exception exception) {
+      resultBuilder.addFailedToDeleteViewIdentifiers(identifier);
+      if (enableStacktrace()) {
+        LOG.error("Failed to delete the view after migration {}", identifier, exception);
+      } else {
+        LOG.error(
+            "Failed to delete the view after migration {} : {}",
             identifier,
             exception.getMessage());
       }
@@ -221,6 +308,30 @@ public abstract class CatalogMigrator {
         LOG.error("Unable to register the table {}", tableIdentifier, ex);
       } else {
         LOG.error("Unable to register the table {} : {}", tableIdentifier, ex.getMessage());
+      }
+      return false;
+    }
+  }
+
+  private String currentViewMetadataFileLocation(TableIdentifier identifier) {
+    ViewOperations ops =
+        ((BaseView) ((ViewCatalog) sourceCatalog()).loadView(identifier)).operations();
+    return ops.current().metadataFileLocation();
+  }
+
+  private boolean registerViewToTargetCatalog(TableIdentifier identifier) {
+    try {
+      createNamespacesIfNotExistOnTargetCatalog(identifier.namespace());
+      // register the view to the target catalog
+      String metadataFileLocation = currentViewMetadataFileLocation(identifier);
+      ((ViewCatalog) targetCatalog()).registerView(identifier, metadataFileLocation);
+      LOG.info("Successfully registered the view {}", identifier);
+      return true;
+    } catch (Exception ex) {
+      if (enableStacktrace()) {
+        LOG.error("Unable to register the view {}", identifier, ex);
+      } else {
+        LOG.error("Unable to register the view {} : {}", identifier, ex.getMessage());
       }
       return false;
     }

--- a/iceberg-catalog-migrator/api/src/test/java/org/apache/polaris/iceberg/catalog/migrator/api/AbstractTestCatalogMigrator.java
+++ b/iceberg-catalog-migrator/api/src/test/java/org/apache/polaris/iceberg/catalog/migrator/api/AbstractTestCatalogMigrator.java
@@ -26,12 +26,16 @@ import nl.altindag.log.model.LogEvent;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.polaris.iceberg.catalog.migrator.api.test.AbstractTest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -65,6 +69,7 @@ public abstract class AbstractTestCatalogMigrator extends AbstractTest {
 
   @AfterEach
   protected void afterEach() {
+    dropViews();
     dropTables();
   }
 
@@ -172,6 +177,61 @@ public abstract class AbstractTestCatalogMigrator extends AbstractTest {
     Assertions.assertThat(targetCatalog.listTables(FOO))
         .containsExactlyInAnyOrder(FOO_TBL1, FOO_TBL2);
     Assertions.assertThat(targetCatalog.listTables(BAR)).containsExactly(BAR_TBL3);
+  }
+
+  @Test
+  public void testMigrateView() {
+    Assumptions.assumeTrue(
+        supportsViewMigration(), "source and target catalogs must support views");
+
+    createView();
+
+    CatalogMigrationResult result =
+        catalogMigratorWithDefaultArgs(true).migrateView(FOO_VIEW1).result();
+
+    Assertions.assertThat(result.registeredViewIdentifiers()).containsExactly(FOO_VIEW1);
+    Assertions.assertThat(result.failedToRegisterViewIdentifiers()).isEmpty();
+    Assertions.assertThat(result.failedToDeleteViewIdentifiers()).isEmpty();
+
+    Assertions.assertThat(((ViewCatalog) targetCatalog).listViews(FOO)).containsExactly(FOO_VIEW1);
+    Assertions.assertThat(((ViewCatalog) sourceCatalog).listViews(FOO)).isEmpty();
+    Assertions.assertThat(sourceCatalog.listTables(FOO))
+        .containsExactlyInAnyOrder(FOO_TBL1, FOO_TBL2);
+  }
+
+  @Test
+  public void testMigrateAllViews() {
+    Assumptions.assumeTrue(
+        supportsViewMigration(), "source and target catalogs must support views");
+
+    createViews();
+
+    CatalogMigrator catalogMigrator = catalogMigratorWithDefaultArgs(true);
+    catalogMigrator.getMatchingViewIdentifiers(null).forEach(catalogMigrator::migrateView);
+    CatalogMigrationResult result = catalogMigrator.result();
+
+    Assertions.assertThat(result.registeredViewIdentifiers())
+        .containsExactlyInAnyOrder(FOO_VIEW2, BAR_VIEW3);
+    Assertions.assertThat(result.failedToRegisterViewIdentifiers()).isEmpty();
+    Assertions.assertThat(result.failedToDeleteViewIdentifiers()).isEmpty();
+
+    Assertions.assertThat(((ViewCatalog) targetCatalog).listViews(FOO)).containsExactly(FOO_VIEW2);
+    Assertions.assertThat(((ViewCatalog) targetCatalog).listViews(BAR)).containsExactly(BAR_VIEW3);
+    Assertions.assertThat(((ViewCatalog) sourceCatalog).listViews(FOO)).isEmpty();
+    Assertions.assertThat(((ViewCatalog) sourceCatalog).listViews(BAR)).isEmpty();
+    Assertions.assertThat(sourceCatalog.listTables(FOO))
+        .containsExactlyInAnyOrder(FOO_TBL1, FOO_TBL2);
+  }
+
+  @Test
+  public void testRegisterViewIsUnsupportedUseMigrate() {
+    Assumptions.assumeTrue(
+        supportsViewMigration(), "source and target catalogs must support views");
+
+    Assertions.assertThatThrownBy(
+            () -> catalogMigratorWithDefaultArgs(false).migrateView(FOO_VIEW1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Registering views is unsupported. Use migrate to migrate views.");
   }
 
   @ParameterizedTest
@@ -341,5 +401,13 @@ public abstract class AbstractTestCatalogMigrator extends AbstractTest {
     CatalogMigrator catalogMigrator = catalogMigratorWithDefaultArgs(deleteSourceTables);
     catalogMigrator.getMatchingTableIdentifiers(null).forEach(catalogMigrator::registerTable);
     return catalogMigrator.result();
+  }
+
+  private static boolean supportsViewMigration() {
+    // Hive view migration is skipped until Iceberg's Hive view metadata lookup is reliable here.
+    // Revisit after https://github.com/apache/iceberg/pull/17532 is available.
+    return sourceCatalog instanceof ViewCatalog
+        && targetCatalog instanceof ViewCatalog
+        && !(sourceCatalog instanceof HiveCatalog);
   }
 }

--- a/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/BaseRegisterCommand.java
+++ b/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/BaseRegisterCommand.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.polaris.iceberg.catalog.migrator.api.CatalogMigrationResult;
 import org.apache.polaris.iceberg.catalog.migrator.api.CatalogMigrator;
 import org.slf4j.Logger;
@@ -89,6 +90,10 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
   public static final String FAILED_IDENTIFIERS_FILE = "failed_identifiers.txt";
   public static final String FAILED_TO_DELETE_AT_SOURCE_FILE = "failed_to_delete_at_source.txt";
   public static final String DRY_RUN_FILE = "dry_run_identifiers.txt";
+  public static final String DRY_RUN_VIEW_FILE = "dry_run_view_identifiers.txt";
+  public static final String FAILED_VIEW_IDENTIFIERS_FILE = "failed_view_identifiers.txt";
+  public static final String FAILED_TO_DELETE_VIEW_AT_SOURCE_FILE =
+      "failed_to_delete_view_at_source.txt";
 
   private static final Logger consoleLog = LoggerFactory.getLogger("console-log");
 
@@ -105,15 +110,29 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
 
   protected abstract String operate();
 
+  protected ViewIdentifierOptions viewIdentifierOptions() {
+    return null;
+  }
+
   @Override
   public Integer call() {
     Set<TableIdentifier> identifiers = Collections.emptySet();
+    Set<TableIdentifier> viewIdentifiers = Collections.emptySet();
+    boolean tableSelectorSpecified = identifierOptions != null;
     String identifierRegEx = identifierOptions != null ? identifierOptions.identifiersRegEx : null;
 
     if (identifierOptions != null) {
       identifiers = identifierOptions.processIdentifiersInput();
     }
-    checkAndWarnAboutIdentifiers(identifiers, identifierRegEx);
+
+    ViewIdentifierOptions viewIdentifierOptions = viewIdentifierOptions();
+    boolean viewSelectorSpecified = viewIdentifierOptions != null;
+    String viewIdentifierRegEx =
+        viewIdentifierOptions != null ? viewIdentifierOptions.identifiersRegEx : null;
+
+    if (viewIdentifierOptions != null) {
+      viewIdentifiers = viewIdentifierOptions.processIdentifiersInput();
+    }
 
     validateOutputDir();
 
@@ -134,29 +153,73 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
       CatalogMigrator catalogMigrator =
           catalogMigrator(sourceCatalog, targetCatalog, enableStackTrace);
 
-      if (identifiers.isEmpty()) {
+      boolean isMigrate = catalogMigrator.deleteEntriesFromSourceCatalog();
+      boolean supportViewMigration =
+          sourceCatalog instanceof ViewCatalog && targetCatalog instanceof ViewCatalog;
+
+      boolean tableSelectionRequested = !viewSelectorSpecified || tableSelectorSpecified;
+      boolean viewSelectionRequested =
+          isMigrate && (!tableSelectorSpecified || viewSelectorSpecified);
+
+      if (identifiers.isEmpty() && tableSelectionRequested) {
+        checkAndWarnAboutIdentifiers(identifierRegEx, "table");
         consoleLog.info("Identifying tables for {} ...", operation());
         identifiers = catalogMigrator.getMatchingTableIdentifiers(identifierRegEx);
         if (identifiers.isEmpty()) {
           consoleLog.warn(
               "No tables were identified for {}. Please check `catalog_migration.log` file for more info.",
               operation());
-          return 1;
         }
+      }
+
+      if (viewSelectorSpecified && !isMigrate) {
+        consoleLog.error("View migration is supported only by the `migrate` command.");
+        return 1;
+      }
+
+      if (viewSelectorSpecified && !supportViewMigration) {
+        consoleLog.error(
+            "View migration is not supported because {} catalog does not support views.",
+            sourceCatalog instanceof ViewCatalog ? "target" : "source");
+        return 1;
+      }
+
+      if (supportViewMigration && viewIdentifiers.isEmpty() && viewSelectionRequested) {
+        checkAndWarnAboutIdentifiers(viewIdentifierRegEx, "view");
+        consoleLog.info("Identifying views for {} ...", operation());
+        viewIdentifiers = catalogMigrator.getMatchingViewIdentifiers(viewIdentifierRegEx);
+        if (viewIdentifiers.isEmpty()) {
+          consoleLog.warn(
+              "No views were identified for {}. Please check `catalog_migration.log` file for more info.",
+              operation());
+        }
+      }
+
+      if (identifiers.isEmpty() && viewIdentifiers.isEmpty()) {
+        String content =
+            supportViewMigration && viewSelectionRequested ? "tables or views" : "tables";
+        consoleLog.warn(
+            "No {} were identified for {}. Please check `catalog_migration.log` file for more info.",
+            content,
+            operation());
+        return 1;
       }
 
       if (isDryRun) {
         consoleLog.info("Dry run is completed.");
-        handleDryRunResult(identifiers);
+        if (tableSelectionRequested) {
+          handleDryRunResult(identifiers);
+        }
+        if (supportViewMigration && viewSelectionRequested && !viewIdentifiers.isEmpty()) {
+          handleDryRunViewResult(viewIdentifiers);
+        }
         return 0;
       }
 
-      consoleLog.info("Identified {} tables for {}.", identifiers.size(), operation());
+      if (!identifiers.isEmpty()) {
+        consoleLog.info("Identified {} tables for {}.", identifiers.size(), operation());
+        consoleLog.info("Started {} ...", operation());
 
-      consoleLog.info("Started {} ...", operation());
-
-      CatalogMigrationResult result;
-      try {
         int processedIdentifiersCount = 0;
         for (TableIdentifier identifier : identifiers) {
           catalogMigrator.registerTable(identifier);
@@ -170,15 +233,36 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
                 identifiers.size());
           }
         }
-      } finally {
-        consoleLog.info("Finished {} ...", operation());
-        result = catalogMigrator.result();
-        handleResults(result);
+        consoleLog.info("Finished {} tables ...", operation());
       }
+
+      if (!viewIdentifiers.isEmpty()) {
+        consoleLog.info("Identified {} views for {}.", viewIdentifiers.size(), operation());
+        consoleLog.info("Started {} ...", operation());
+
+        int processedViewIdentifiersCount = 0;
+        for (TableIdentifier identifier : viewIdentifiers) {
+          catalogMigrator.migrateView(identifier);
+          processedViewIdentifiersCount++;
+          if (processedViewIdentifiersCount % BATCH_SIZE == 0
+              || processedViewIdentifiersCount == viewIdentifiers.size()) {
+            consoleLog.info(
+                "Attempted {} for {} views out of {} views.",
+                operation(),
+                processedViewIdentifiersCount,
+                viewIdentifiers.size());
+          }
+        }
+        consoleLog.info("Finished {} views ...", operation());
+      }
+
+      CatalogMigrationResult result = catalogMigrator.result();
+      handleResults(result);
 
       if (!result.failedToRegisterTableIdentifiers().isEmpty()
           || !result.failedToDeleteTableIdentifiers().isEmpty()
-          || result.registeredTableIdentifiers().isEmpty()) {
+          || !result.failedToRegisterViewIdentifiers().isEmpty()
+          || !result.failedToDeleteViewIdentifiers().isEmpty()) {
         return 1;
       }
 
@@ -199,20 +283,21 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
     }
   }
 
-  private void checkAndWarnAboutIdentifiers(
-      Set<TableIdentifier> identifiers, String identifierRegEx) {
-    if (identifiers.isEmpty()) {
-      if (identifierRegEx != null) {
-        consoleLog.warn(
-            "User has not specified the table identifiers."
-                + " Will be selecting all the tables from all the namespaces from the source catalog "
-                + "which matches the regex pattern:{}",
-            identifierRegEx);
-      } else {
-        consoleLog.warn(
-            "User has not specified the table identifiers."
-                + " Will be selecting all the tables from all the namespaces from the source catalog.");
-      }
+  private void checkAndWarnAboutIdentifiers(String identifierRegEx, String content) {
+    if (identifierRegEx != null) {
+      consoleLog.warn(
+          "User has not specified the {} identifiers."
+              + " Will be selecting all the {}s from all the namespaces from the source catalog "
+              + "which matches the regex pattern:{}",
+          content,
+          content,
+          identifierRegEx);
+    } else {
+      consoleLog.warn(
+          "User has not specified the {} identifiers."
+              + " Will be selecting all the {}s from all the namespaces from the source catalog.",
+          content,
+          content);
     }
   }
 
@@ -237,6 +322,16 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
       writeToFile(
           outputDirPath.resolve(FAILED_TO_DELETE_AT_SOURCE_FILE),
           result.failedToDeleteTableIdentifiers());
+      if (!result.failedToRegisterViewIdentifiers().isEmpty()) {
+        writeToFile(
+            outputDirPath.resolve(FAILED_VIEW_IDENTIFIERS_FILE),
+            result.failedToRegisterViewIdentifiers());
+      }
+      if (!result.failedToDeleteViewIdentifiers().isEmpty()) {
+        writeToFile(
+            outputDirPath.resolve(FAILED_TO_DELETE_VIEW_AT_SOURCE_FILE),
+            result.failedToDeleteViewIdentifiers());
+      }
     } finally {
       printSummary(result);
       printDetails(result);
@@ -248,6 +343,14 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
       writeToFile(outputDirPath.resolve(DRY_RUN_FILE), identifiers);
     } finally {
       printDryRunResult(identifiers);
+    }
+  }
+
+  private void handleDryRunViewResult(Set<TableIdentifier> identifiers) {
+    try {
+      writeToFile(outputDirPath.resolve(DRY_RUN_VIEW_FILE), identifiers);
+    } finally {
+      printDryRunViewResult(identifiers);
     }
   }
 
@@ -284,6 +387,37 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
           System.lineSeparator(),
           FAILED_TO_DELETE_AT_SOURCE_FILE);
     }
+    if (!result.registeredViewIdentifiers().isEmpty()) {
+      consoleLog.info(
+          "Successfully {} {} views from {} catalog to {} catalog.",
+          operated(),
+          result.registeredViewIdentifiers().size(),
+          sourceCatalogOptions.type.name(),
+          targetCatalogOptions.type.name());
+    }
+    if (!result.failedToRegisterViewIdentifiers().isEmpty()) {
+      consoleLog.error(
+          "Failed to {} {} views from {} catalog to {} catalog. "
+              + "Please check the `catalog_migration.log` file for the failure reason. "
+              + "Failed identifiers are written into `{}`. "
+              + "Retry with that file using `--view-identifiers-from-file` option "
+              + "if the failure is because of network/connection timeouts.",
+          operate(),
+          result.failedToRegisterViewIdentifiers().size(),
+          sourceCatalogOptions.type.name(),
+          targetCatalogOptions.type.name(),
+          FAILED_VIEW_IDENTIFIERS_FILE);
+    }
+    if (!result.failedToDeleteViewIdentifiers().isEmpty()) {
+      consoleLog.error(
+          "Failed to delete {} views from {} catalog. "
+              + "Please check the `catalog_migration.log` file for the failure reason. "
+              + "{}Failed to delete identifiers are written into `{}`.",
+          result.failedToDeleteViewIdentifiers().size(),
+          sourceCatalogOptions.type.name(),
+          System.lineSeparator(),
+          FAILED_TO_DELETE_VIEW_AT_SOURCE_FILE);
+    }
   }
 
   private void printDetails(CatalogMigrationResult result) {
@@ -310,6 +444,29 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
           System.lineSeparator(),
           result.failedToDeleteTableIdentifiers());
     }
+
+    if (!result.registeredViewIdentifiers().isEmpty()) {
+      consoleLog.info(
+          "Successfully {} these views:{}{}",
+          operated(),
+          System.lineSeparator(),
+          result.registeredViewIdentifiers());
+    }
+
+    if (!result.failedToRegisterViewIdentifiers().isEmpty()) {
+      consoleLog.error(
+          "Failed to {} these views:{}{}",
+          operate(),
+          System.lineSeparator(),
+          result.failedToRegisterViewIdentifiers());
+    }
+
+    if (!result.failedToDeleteViewIdentifiers().isEmpty()) {
+      consoleLog.error(
+          "Failed to delete these views from source catalog:{}{}",
+          System.lineSeparator(),
+          result.failedToDeleteViewIdentifiers());
+    }
   }
 
   private void printDryRunResult(Set<TableIdentifier> result) {
@@ -322,6 +479,22 @@ public abstract class BaseRegisterCommand implements Callable<Integer> {
         DRY_RUN_FILE);
     consoleLog.info(
         "Details: {}Identified these tables for {} by dry-run:{}{}",
+        System.lineSeparator(),
+        operation(),
+        System.lineSeparator(),
+        result);
+  }
+
+  private void printDryRunViewResult(Set<TableIdentifier> result) {
+    consoleLog.info("Summary: ");
+    consoleLog.info(
+        "Identified {} views for {} by dry-run. These identifiers are also written into {}. "
+            + "This file can be used with `--view-identifiers-from-file` option for an actual run.",
+        result.size(),
+        operation(),
+        DRY_RUN_VIEW_FILE);
+    consoleLog.info(
+        "Details: {}Identified these views for {} by dry-run:{}{}",
         System.lineSeparator(),
         operation(),
         System.lineSeparator(),

--- a/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/MigrateCommand.java
+++ b/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/MigrateCommand.java
@@ -35,13 +35,21 @@ import picocli.CommandLine;
     // of sorted order.
     sortOptions = false,
     description =
-        "Bulk migrate the iceberg tables from source catalog to target catalog without data copy."
-            + " Table entries from source catalog will be deleted after the successful migration to the target "
-            + "catalog.")
+        "Bulk migrate the iceberg tables and views from source catalog to target catalog without "
+            + "data copy. Table and view entries from source catalog will be deleted after the "
+            + "successful migration to the target catalog.")
 public class MigrateCommand extends BaseRegisterCommand {
 
   private static final String newLine = System.lineSeparator();
   private static final Logger consoleLog = LoggerFactory.getLogger("console-log");
+
+  @CommandLine.ArgGroup(heading = "View identifier options: %n")
+  private ViewIdentifierOptions viewIdentifierOptions;
+
+  @Override
+  protected ViewIdentifierOptions viewIdentifierOptions() {
+    return viewIdentifierOptions;
+  }
 
   @Override
   protected CatalogMigrator catalogMigrator(
@@ -75,7 +83,7 @@ public class MigrateCommand extends BaseRegisterCommand {
             + "{}\tSo, while using this tool please make sure there are no in-progress commits for the source "
             + "catalog.{}"
             + "{}"
-            + "\tb) After the migration, successfully migrated tables will be deleted from the source catalog "
+            + "\tb) After the migration, successfully migrated tables and views will be deleted from the source catalog "
             + "{}\tand can only be accessed from the target catalog.",
         newLine,
         newLine,

--- a/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/ViewIdentifierOptions.java
+++ b/iceberg-catalog-migrator/cli/src/main/java/org/apache/polaris/iceberg/catalog/migrator/cli/ViewIdentifierOptions.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.iceberg.catalog.migrator.cli;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+public class ViewIdentifierOptions {
+
+  @CommandLine.Option(
+      names = {"--view-identifiers"},
+      split = ",",
+      description = {
+        "Optional selective set of view identifiers to migrate. Use this when there are few view identifiers that "
+            + "need to be migrated. For a large number of view identifiers, use the `--view-identifiers-from-file` "
+            + "or `--view-identifiers-regex` option.",
+        "Example: --view-identifiers foo.v1,bar.v2"
+      })
+  protected Set<String> identifiers = new HashSet<>();
+
+  @CommandLine.Option(
+      names = {"--view-identifiers-from-file"},
+      description = {
+        "Optional text file path that contains a set of view identifiers (one per line) to migrate. Should not be "
+            + "used with `--view-identifiers` or `--view-identifiers-regex` option.",
+        "Example: --view-identifiers-from-file /tmp/files/ids.txt"
+      })
+  protected String identifiersFromFile;
+
+  @CommandLine.Option(
+      names = {"--view-identifiers-regex"},
+      description = {
+        "Optional regular expression pattern used to migrate only the views whose view identifiers match this pattern. "
+            + "Should not be used with `--view-identifiers` or '--view-identifiers-from-file' option.",
+        "Example: --view-identifiers-regex ^foo\\..*"
+      })
+  protected String identifiersRegEx;
+
+  private static final Logger consoleLog = LoggerFactory.getLogger("console-log");
+
+  protected Set<TableIdentifier> processIdentifiersInput() {
+
+    if (!identifiers.isEmpty()) {
+      return identifiers.stream()
+          .map(TableIdentifier::parse)
+          .collect(Collectors.toCollection(LinkedHashSet::new));
+    } else if (identifiersFromFile != null) {
+      Preconditions.checkArgument(
+          Files.exists(Paths.get(identifiersFromFile)),
+          "File specified in `--view-identifiers-from-file` option does not exist");
+      try {
+        consoleLog.info("Collecting view identifiers from the file {} ...", identifiersFromFile);
+        return Files.readAllLines(Paths.get(identifiersFromFile)).stream()
+            .map(String::trim)
+            .filter(string -> !string.isEmpty())
+            .map(TableIdentifier::parse)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+            String.format("Failed to read the file: %s", identifiersFromFile), e);
+      }
+    } else if (identifiersRegEx != null) {
+      Preconditions.checkArgument(
+          !identifiersRegEx.trim().isEmpty(), "--view-identifiers-regex should not be empty");
+      // check whether pattern is compilable
+      try {
+        Pattern.compile(identifiersRegEx);
+      } catch (PatternSyntaxException ex) {
+        throw new IllegalArgumentException(
+            "--view-identifiers-regex pattern is not compilable", ex);
+      }
+    }
+    return Sets.newHashSet();
+  }
+}

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/AbstractCLIMigrationTest.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/AbstractCLIMigrationTest.java
@@ -32,13 +32,17 @@ import java.util.Map;
 import nl.altindag.log.LogCaptor;
 import nl.altindag.log.model.LogEvent;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.polaris.iceberg.catalog.migrator.api.CatalogMigrationUtil;
 import org.apache.polaris.iceberg.catalog.migrator.api.CatalogMigrator;
 import org.apache.polaris.iceberg.catalog.migrator.api.test.AbstractTest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -109,11 +113,14 @@ public abstract class AbstractCLIMigrationTest extends AbstractTest {
 
   @BeforeEach
   protected void beforeEach() {
+    dropViews();
+    dropTables();
     createTables();
   }
 
   @AfterEach
   protected void afterEach() {
+    dropViews();
     dropTables();
   }
 
@@ -164,6 +171,73 @@ public abstract class AbstractCLIMigrationTest extends AbstractTest {
       Assertions.assertThat(sourceCatalog.listTables(BAR))
           .containsExactlyInAnyOrder(BAR_TBL3, BAR_TBL4);
     }
+  }
+
+  @Test
+  public void testMigrateSelectedViews() throws Exception {
+    Assumptions.assumeTrue(
+        supportsViewMigration(), "source and target catalogs must support views");
+
+    createView();
+
+    List<String> argsList = defaultArgs();
+    argsList.addAll(Arrays.asList("--view-identifiers", FOO_VIEW1.toString()));
+    RunCLI run = runCLI(true, argsList);
+
+    Assertions.assertThat(run.getExitCode()).isEqualTo(0);
+    Assertions.assertThat(run.getOut())
+        .doesNotContain("Identified 4 tables for migration.")
+        .contains("Identified 1 views for migration.")
+        .contains(
+            String.format(
+                "Summary: %nSuccessfully migrated 1 views from %s catalog to %s catalog.",
+                sourceCatalogType, targetCatalogType))
+        .contains(String.format("Details: %nSuccessfully migrated these views:%n[%s]", FOO_VIEW1));
+
+    Assertions.assertThat(targetCatalog.listTables(FOO)).isEmpty();
+    Assertions.assertThat(targetCatalog.listTables(BAR)).isEmpty();
+    Assertions.assertThat(((ViewCatalog) targetCatalog).listViews(FOO)).contains(FOO_VIEW1);
+
+    Assertions.assertThat(sourceCatalog.listTables(FOO))
+        .containsExactlyInAnyOrder(FOO_TBL1, FOO_TBL2);
+    Assertions.assertThat(sourceCatalog.listTables(BAR))
+        .containsExactlyInAnyOrder(BAR_TBL3, BAR_TBL4);
+    Assertions.assertThat(((ViewCatalog) sourceCatalog).listViews(FOO)).isEmpty();
+  }
+
+  @Test
+  public void testMigrateAllTablesAndViews() throws Exception {
+    Assumptions.assumeTrue(
+        supportsViewMigration(), "source and target catalogs must support views");
+
+    createViews();
+
+    RunCLI run = runCLI(true, defaultArgs());
+
+    Assertions.assertThat(run.getExitCode()).isEqualTo(0);
+    Assertions.assertThat(run.getOut())
+        .contains("Identified 4 tables for migration.")
+        .contains("Identified 2 views for migration.")
+        .contains(
+            String.format(
+                "Summary: %n"
+                    + "Successfully migrated 4 tables from %s catalog to %s catalog.%n"
+                    + "Successfully migrated 2 views from %s catalog to %s catalog.",
+                sourceCatalogType, targetCatalogType, sourceCatalogType, targetCatalogType))
+        .contains(String.format("Details: %nSuccessfully migrated these tables:%n"))
+        .contains(String.format("Successfully migrated these views:%n"));
+
+    Assertions.assertThat(targetCatalog.listTables(FOO))
+        .containsExactlyInAnyOrder(FOO_TBL1, FOO_TBL2);
+    Assertions.assertThat(targetCatalog.listTables(BAR))
+        .containsExactlyInAnyOrder(BAR_TBL3, BAR_TBL4);
+    Assertions.assertThat(((ViewCatalog) targetCatalog).listViews(FOO)).contains(FOO_VIEW2);
+    Assertions.assertThat(((ViewCatalog) targetCatalog).listViews(BAR)).containsExactly(BAR_VIEW3);
+
+    Assertions.assertThat(sourceCatalog.listTables(FOO)).isEmpty();
+    Assertions.assertThat(sourceCatalog.listTables(BAR)).isEmpty();
+    Assertions.assertThat(((ViewCatalog) sourceCatalog).listViews(FOO)).isEmpty();
+    Assertions.assertThat(((ViewCatalog) sourceCatalog).listViews(BAR)).isEmpty();
   }
 
   @ParameterizedTest
@@ -385,8 +459,9 @@ public abstract class AbstractCLIMigrationTest extends AbstractTest {
   public void testRegisterNoTables(boolean deleteSourceTables) throws Exception {
     validateAssumptionForHadoopCatalogAsSource(deleteSourceTables);
 
-    // clean up the default tables present in the source catalog.
+    // clean up the default tables and views present in the source catalog.
     dropTables();
+    dropViews();
 
     RunCLI run = runCLI(deleteSourceTables, defaultArgs());
 
@@ -482,5 +557,13 @@ public abstract class AbstractCLIMigrationTest extends AbstractTest {
       argsList.add(0, "migrate");
     }
     return RunCLI.run(argsList.toArray(new String[0]));
+  }
+
+  private static boolean supportsViewMigration() {
+    // Hive view migration is skipped until Iceberg's Hive view metadata lookup is reliable here.
+    // Revisit after https://github.com/apache/iceberg/pull/17532 is available.
+    return sourceCatalog instanceof ViewCatalog
+        && targetCatalog instanceof ViewCatalog
+        && !(sourceCatalog instanceof HiveCatalog);
   }
 }

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/CLIOptionsTest.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/CLIOptionsTest.java
@@ -160,6 +160,61 @@ public class CLIOptionsTest {
     executeAndValidateResults("migrate", args, expectedMessage, 2);
   }
 
+  @Test
+  public void testViewOptionsAreOnlyAcceptedForMigrate() throws Exception {
+    executeAndValidateResults(
+        "register",
+        Lists.newArrayList("--view-identifiers", "foo.view1"),
+        "Unknown options: '--view-identifiers', 'foo.view1'",
+        2);
+  }
+
+  @Test
+  public void testViewIdentifierOptionsAreMutuallyExclusiveForMigrate() throws Exception {
+    List<String> args =
+        Lists.newArrayList(
+            "--source-catalog-type",
+            "HADOOP",
+            "--source-catalog-properties",
+            "k1=v1,k2=v2",
+            "--target-catalog-type",
+            "HIVE",
+            "--target-catalog-properties",
+            "k3=v3, k4=v4",
+            "--view-identifiers",
+            "foo.view1",
+            "--view-identifiers-from-file",
+            "file.txt",
+            "--view-identifiers-regex",
+            "^foo\\.");
+    String expectedMessage =
+        "Error: --view-identifiers=<identifiers>, --view-identifiers-from-file=<identifiersFromFile>, --view-identifiers-regex=<identifiersRegEx> are mutually exclusive (specify only one)";
+
+    executeAndValidateResults("migrate", args, expectedMessage, 2);
+  }
+
+  @Test
+  public void testViewIdentifierAndRegexOptionsAreMutuallyExclusiveForMigrate() throws Exception {
+    List<String> args =
+        Lists.newArrayList(
+            "--source-catalog-type",
+            "HADOOP",
+            "--source-catalog-properties",
+            "k1=v1,k2=v2",
+            "--target-catalog-type",
+            "HIVE",
+            "--target-catalog-properties",
+            "k3=v3, k4=v4",
+            "--view-identifiers",
+            "foo.view1",
+            "--view-identifiers-regex",
+            "^foo\\.");
+    String expectedMessage =
+        "Error: --view-identifiers=<identifiers>, --view-identifiers-regex=<identifiersRegEx> are mutually exclusive (specify only one)";
+
+    executeAndValidateResults("migrate", args, expectedMessage, 2);
+  }
+
   private static Stream<Arguments> invalidArgs() {
     return Stream.of(
         arguments(

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/ITHadoopToPolarisCLIMigrationTest.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/ITHadoopToPolarisCLIMigrationTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import org.apache.polaris.iceberg.catalog.migrator.api.CatalogMigrationUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 public class ITHadoopToPolarisCLIMigrationTest extends AbstractCLIMigrationTest {
 
@@ -32,13 +34,38 @@ public class ITHadoopToPolarisCLIMigrationTest extends AbstractCLIMigrationTest 
 
   @BeforeAll
   protected static void setup() throws Exception {
+    restartPolarisContainer();
+    initializeSourceCatalog(CatalogMigrationUtil.CatalogType.HADOOP, Collections.emptyMap());
+  }
+
+  @Override
+  protected void beforeEach() {
+    // Replaced by the TestInfo-aware setup below.
+  }
+
+  @BeforeEach
+  protected void beforeEach(TestInfo testInfo) {
+    if (requiresEmptyTargetCatalog(testInfo)) {
+      restartPolarisContainer();
+    }
+    dropViews();
+    dropTables();
+    createTables();
+  }
+
+  private static void restartPolarisContainer() {
+    if (polarisContainer != null) {
+      polarisContainer.stop();
+    }
     polarisContainer = new PolarisContainer(sourceCatalogWarehouse);
     polarisContainer.start();
 
-    assertThat(polarisContainer.httpGet("/api/management/v1/catalogs"))
-        .contains(PolarisContainer.CATALOG_NAME);
-
-    initializeSourceCatalog(CatalogMigrationUtil.CatalogType.HADOOP, Collections.emptyMap());
+    try {
+      assertThat(polarisContainer.httpGet("/api/management/v1/catalogs"))
+          .contains(PolarisContainer.CATALOG_NAME);
+    } catch (Exception e) {
+      throw new AssertionError("Error listing Polaris catalogs", e);
+    }
 
     initializeTargetCatalog(
         CatalogMigrationUtil.CatalogType.REST,
@@ -50,6 +77,17 @@ public class ITHadoopToPolarisCLIMigrationTest extends AbstractCLIMigrationTest 
             "token",
             polarisContainer.getAccessToken(
                 polarisContainer.getClientId(), polarisContainer.getClientSecret())));
+  }
+
+  private static boolean requiresEmptyTargetCatalog(TestInfo testInfo) {
+    return testInfo
+        .getTestMethod()
+        .map(
+            method ->
+                method.getName().equals("testRegister")
+                    || method.getName().equals("testRegisterWithFewFailures")
+                    || method.getName().equals("testRegisterSelectedTables"))
+        .orElse(false);
   }
 
   @AfterAll

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/ITNessieToPolarisCLIMigrationTest.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/ITNessieToPolarisCLIMigrationTest.java
@@ -53,7 +53,7 @@ public class ITNessieToPolarisCLIMigrationTest extends AbstractCLIMigrationTest 
 
   @AfterAll
   protected static void tearDown() throws Exception {
-    dropNamespaces();
+    dropSourceNamespaces();
 
     if (polarisContainer != null) {
       polarisContainer.stop();

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/PolarisContainer.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/PolarisContainer.java
@@ -57,6 +57,7 @@ public class PolarisContainer extends GenericContainer<PolarisContainer> {
     Preconditions.checkArgument(hostDirectory != null, "host directory is null");
     this.hostDirectory = hostDirectory;
     this.withFileSystemBind(hostDirectory, hostDirectory, BindMode.READ_WRITE);
+    this.withStartupAttempts(5);
     Wait.forHttp("/").forStatusCode(200);
     this.withExposedPorts(POLARIS_PORT).withEnv("JAVA_TOOL_OPTIONS", "-Duser.dir=" + hostDirectory);
   }

--- a/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/ProcessIdentifiersTest.java
+++ b/iceberg-catalog-migrator/cli/src/test/java/org/apache/polaris/iceberg/catalog/migrator/cli/ProcessIdentifiersTest.java
@@ -43,6 +43,7 @@ public class ProcessIdentifiersTest {
   public void testIdentifiersSet() {
     // test empty set
     Assertions.assertThat(new IdentifierOptions().processIdentifiersInput()).isEmpty();
+    Assertions.assertThat(new ViewIdentifierOptions().processIdentifiersInput()).isEmpty();
 
     // test valid elements
     IdentifierOptions identifierOptions = new IdentifierOptions();
@@ -50,6 +51,12 @@ public class ProcessIdentifiersTest {
     Assertions.assertThat(identifierOptions.processIdentifiersInput())
         .containsExactlyInAnyOrder(
             TableIdentifier.parse("foo.abc"), TableIdentifier.parse("bar.def"));
+
+    ViewIdentifierOptions viewIdentifierOptions = new ViewIdentifierOptions();
+    viewIdentifierOptions.identifiers = Sets.newHashSet("foo.view1", "bar.view2");
+    Assertions.assertThat(viewIdentifierOptions.processIdentifiersInput())
+        .containsExactlyInAnyOrder(
+            TableIdentifier.parse("foo.view1"), TableIdentifier.parse("bar.view2"));
   }
 
   @Test
@@ -115,6 +122,13 @@ public class ProcessIdentifiersTest {
     Assertions.assertThatThrownBy(options::processIdentifiersInput)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("File specified in `--identifiers-from-file` option does not exist");
+
+    ViewIdentifierOptions viewOptions = new ViewIdentifierOptions();
+    viewOptions.identifiersFromFile = "path/to/file";
+    Assertions.assertThatThrownBy(viewOptions::processIdentifiersInput)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "File specified in `--view-identifiers-from-file` option does not exist");
   }
 
   @Test
@@ -135,5 +149,17 @@ public class ProcessIdentifiersTest {
     Assertions.assertThatThrownBy(options::processIdentifiersInput)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("--identifiers-regex should not be empty");
+
+    ViewIdentifierOptions viewOptions = new ViewIdentifierOptions();
+    viewOptions.identifiersRegEx = "(23erf423!";
+    Assertions.assertThatThrownBy(viewOptions::processIdentifiersInput)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("--view-identifiers-regex pattern is not compilable");
+
+    viewOptions = new ViewIdentifierOptions();
+    viewOptions.identifiersRegEx = "  ";
+    Assertions.assertThatThrownBy(viewOptions::processIdentifiersInput)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("--view-identifiers-regex should not be empty");
   }
 }

--- a/iceberg-catalog-migrator/docs/examples.md
+++ b/iceberg-catalog-migrator/docs/examples.md
@@ -117,6 +117,29 @@ java -jar iceberg-catalog-migrator-cli-0.0.1.jar migrate \
 --identifiers-from-file ids.txt
 ```
 
+### Migrate Selected Views
+
+View migration is supported only by the `migrate` command. If no table or view selectors are
+provided, `migrate` identifies all tables and all views supported by both catalogs. Use view
+selectors when only specific views should be migrated. `--view-identifiers-from-file` and
+`--view-identifiers-regex` are also available and behave like the table selector options.
+
+| Table selector | View selector | What happens |
+|---|---|---|
+| Not specified | Not specified | Migrates **all tables** and **all views** |
+| Specified | Not specified | Migrates **selected tables only**, no views |
+| Not specified | Specified | Migrates **selected views only**, no tables |
+| Specified | Specified | Migrates **selected tables** and **selected views** |
+
+```shell
+java -jar iceberg-catalog-migrator-cli-0.0.1.jar migrate \
+--source-catalog-type REST \
+--source-catalog-properties uri=http://sourcecatalog:8181/api/catalog,warehouse=test,token=$TOKEN_SOURCE \
+--target-catalog-type REST  \
+--target-catalog-properties uri=http://targetcatalog:8181/api/catalog,warehouse=test,token=$TOKEN_TARGET \
+--view-identifiers foo.view1,foo.view2
+```
+
 
 ## Tips
 1. Before migrating tables to Polaris, make sure the catalog is configured to the `base-location` same as source catalog `warehouse` location during catalog creation.

--- a/iceberg-catalog-migrator/docs/getting-started.md
+++ b/iceberg-catalog-migrator/docs/getting-started.md
@@ -34,7 +34,7 @@ Migration happens in five steps:
 2. Set the object storage environment variables
 3. Get access to the source and target catalogs
 4. Validate the migration
-5. Migrate the tables
+5. Migrate tables and views
 
 ### Step 1: Build the Iceberg Catalog Migrator
 Execute the following commands to build the tool:
@@ -82,14 +82,15 @@ export TOKEN_TARGET=xxxxxxx
 ```
 
 ### Step 4: Validate the Migration
-Execute the following command to understand how to migrate the tables:
+Execute the following command to understand how to migrate tables and views:
 ```shell
-java -jar ./cli/build/libs/iceberg-catalog-migrator-cli-0.0.1-SNAPSHOT.jar register -h  
+java -jar ./cli/build/libs/iceberg-catalog-migrator-cli-0.0.1-SNAPSHOT.jar migrate -h
 ```
 
-In the example, execute the following command to perform a dry run migration. This will not migrate the tables but will provide information on the operation:
+In the example, execute the following command to perform a dry run migration. This will not migrate
+tables or views, but will provide information on the operation:
 ```shell
-java -jar ./cli/build/libs/iceberg-catalog-migrator-cli-0.0.1-SNAPSHOT.jar register \
+java -jar ./cli/build/libs/iceberg-catalog-migrator-cli-0.0.1-SNAPSHOT.jar migrate \
 --source-catalog-type REST \
 --source-catalog-properties uri=http://sourcecatalog:8181/api/catalog,warehouse=test,token=$TOKEN_SOURCE \
 --target-catalog-type REST  \
@@ -97,9 +98,12 @@ java -jar ./cli/build/libs/iceberg-catalog-migrator-cli-0.0.1-SNAPSHOT.jar regis
 --dry-run
 ```
 
-After validating all inputs, the console will display a list of table identifiers that are identified for migration. This information will also be written to a file called `dry_run.txt`,
+After validating all inputs, the console will display the table identifiers identified for
+migration. When both catalogs support Iceberg views, it also displays the view identifiers
+identified for migration. Table identifiers are written to `dry_run_identifiers.txt`; view
+identifiers are written to `dry_run_view_identifiers.txt` when views are identified.
 
-### Step 5: Migrate the Tables
+### Step 5: Migrate Tables and Views
 
 In the example, execute the following command to perform a migration:
 ```shell
@@ -109,6 +113,20 @@ java -jar ./cli/build/libs/iceberg-catalog-migrator-cli-0.0.1-SNAPSHOT.jar migra
 --target-catalog-type REST  \
 --target-catalog-properties uri=http://targetcatalog:8181/api/catalog,warehouse=test,token=$TOKEN_TARGET
 ```
+
+When both catalogs support Iceberg views, the same `migrate` command also migrates views. To migrate
+specific views, use view selector options:
+```shell
+java -jar ./cli/build/libs/iceberg-catalog-migrator-cli-0.0.1-SNAPSHOT.jar migrate \
+--source-catalog-type REST \
+--source-catalog-properties uri=http://sourcecatalog:8181/api/catalog,warehouse=test,token=$TOKEN_SOURCE \
+--target-catalog-type REST  \
+--target-catalog-properties uri=http://targetcatalog:8181/api/catalog,warehouse=test,token=$TOKEN_TARGET \
+--view-identifiers foo.view1,foo.view2
+```
+
+View migration is supported only by the `migrate` command. The `register` command remains table-only
+because Iceberg view deletion does not expose a purge-false mode equivalent to table migration.
 
 Please note that a log file will be created to verify the migration proceeded successfully.
 If any issues occur, please use [the troubleshooting guide](./troubleshooting.md).


### PR DESCRIPTION
## Summary

Adds Iceberg view migration support to the Iceberg Catalog Migrator.

The migrator now supports migrating both Iceberg tables and Iceberg views from a source catalog to a target catalog without copying data. View migration uses the new Iceberg `ViewCatalog.registerView` support added in Iceberg 1.11.0, which registers a view in the target catalog from the source view metadata location.

By default, the `migrate` command now migrates both tables and views when both source and target catalogs support Iceberg views. Existing table-only selector behavior is preserved for users who explicitly provide table selectors.

## New Options

Adds view selector options to the `migrate` command:

| Option | Description |
|---|---|
| `--view-identifiers` | Comma-separated list of view identifiers to migrate |
| `--view-identifiers-from-file` | File containing one view identifier per line |
| `--view-identifiers-regex` | Regex used to select matching view identifiers |

Selector behavior:

| Table selector | View selector | What happens |
|---|---|---|
| Not specified | Not specified | Migrates **all tables** and **all views** |
| Specified | Not specified | Migrates **selected tables only**, no views |
| Not specified | Specified | Migrates **selected views only**, no tables |
| Specified | Specified | Migrates **selected tables** and **selected views** |

## Why Views Are Supported Only With `migrate`

View support is intentionally added only to the `migrate` command, not the `register` command.

For tables, `register` can leave the table entry in both source and target catalogs. That is already risky and documented, but table cleanup can use `dropTable(..., purge=false)` when migrating so only the catalog entry is removed from the source.

Iceberg views do not have an equivalent purge-false delete operation. Dropping a view is a lightweight catalog operation, so view migration must delete the successfully migrated view from the source catalog after registering it in the target catalog. Because of that, view migration requires `migrate` semantics and is rejected for `register`.

## Notes

- View migration runs only when both source and target catalogs implement Iceberg view support.
- Table migration and view migration are tracked independently in the result summary.
- Failures for tables or views are reported separately, and failed identifiers can be retried using the existing table selector options or the new view selector options.
- Documentation and examples are updated to show table and view migration usage.