### PR TITLE
fix(console): allow setting connection-type-specific fields on EXTERNAL catalogs

### DIFF
--- a/console/src/components/forms/CreateCatalogModal.tsx
+++ b/console/src/components/forms/CreateCatalogModal.tsx
@@ -79,6 +79,8 @@ const schema = z
     // External connection (only when type === EXTERNAL)
     connectionType: z.enum(["ICEBERG_REST", "HADOOP", "HIVE"]).optional(),
     conn_uri: z.string().optional(),
+    conn_remoteCatalogName: z.string().optional(),
+    conn_warehouse: z.string().optional(),
     auth_type: z.enum(["OAUTH", "BEARER", "SIGV4", "IMPLICIT"]).optional(),
     // OAUTH
     oauth_tokenUri: z.string().optional(),
@@ -142,6 +144,7 @@ export function CreateCatalogModal({ open, onOpenChange, onCreated }: CreateCata
 
   const storageType = watch("storageType")
   const catalogType = watch("type")
+  const connectionType = watch("connectionType")
   const authType = watch("auth_type")
 
   const createMutation = useMutation({
@@ -233,6 +236,14 @@ export function CreateCatalogModal({ open, onOpenChange, onCreated }: CreateCata
           connectionType: values.connectionType!,
         }
         if (values.conn_uri) connectionConfigInfo.uri = values.conn_uri
+        // Type-gated, not just presence: RHF keeps values for unmounted inputs.
+        if (values.connectionType === "ICEBERG_REST") {
+          if (values.conn_remoteCatalogName)
+            connectionConfigInfo.remoteCatalogName = values.conn_remoteCatalogName
+        }
+        if (values.connectionType === "HADOOP" || values.connectionType === "HIVE") {
+          if (values.conn_warehouse) connectionConfigInfo.warehouse = values.conn_warehouse
+        }
         if (authenticationParameters)
           connectionConfigInfo.authenticationParameters = authenticationParameters
 
@@ -462,6 +473,28 @@ export function CreateCatalogModal({ open, onOpenChange, onCreated }: CreateCata
                 <p className="mt-1 text-xs text-muted-foreground">
                   URI to the remote catalog service (if applicable).
                 </p>
+                {connectionType === "ICEBERG_REST" && (
+                  <>
+                    <Input
+                      placeholder="Remote catalog name (optional)"
+                      {...register("conn_remoteCatalogName")}
+                    />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Name of the catalog within the remote service. Often becomes a prefix on the
+                      remote's REST paths. Older systems may call this the warehouse.
+                    </p>
+                  </>
+                )}
+                {(connectionType === "HADOOP" || connectionType === "HIVE") && (
+                  <>
+                    <Input placeholder="Warehouse (optional)" {...register("conn_warehouse")} />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {connectionType === "HADOOP"
+                        ? "The file path to where this catalog should store tables."
+                        : "The warehouse location for the hive catalog."}
+                    </p>
+                  </>
+                )}
               </div>
               <Controller
                 name="auth_type"

--- a/console/src/pages/CatalogDetails.tsx
+++ b/console/src/pages/CatalogDetails.tsx
@@ -293,6 +293,24 @@ export function CatalogDetails() {
                         </span>
                       </div>
                     )}
+                    {catalog.connectionConfigInfo.remoteCatalogName && (
+                      <div className="flex gap-2 mt-2">
+                        <span className="font-mono text-sm text-muted-foreground">
+                          Remote Catalog Name:
+                        </span>
+                        <span className="font-mono text-sm">
+                          {catalog.connectionConfigInfo.remoteCatalogName}
+                        </span>
+                      </div>
+                    )}
+                    {catalog.connectionConfigInfo.warehouse && (
+                      <div className="flex gap-2 mt-2">
+                        <span className="font-mono text-sm text-muted-foreground">Warehouse:</span>
+                        <span className="font-mono text-sm">
+                          {catalog.connectionConfigInfo.warehouse}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -45,6 +45,10 @@ export interface ConnectionConfigInfo {
   uri?: string
   authenticationParameters?: unknown
   serviceIdentity?: unknown
+  // ICEBERG_REST-specific
+  remoteCatalogName?: string
+  // HADOOP/HIVE-specific
+  warehouse?: string
 }
 
 export interface Catalog {


### PR DESCRIPTION
## Problem

The create-catalog form supports `EXTERNAL` catalogs but collects none of the connection-type-specific fields, because `ConnectionConfigInfo` in `console/src/types/api.ts` mirrors only the spec's base schema:

| Connection type | Missing field | Declared on |
|---|---|---|
| `ICEBERG_REST` | `remoteCatalogName` | [`IcebergRestConnectionConfigInfo`](https://github.com/apache/polaris-tools/blob/e5fea020aedcb1834f306d9a13de7fccbfff1943/console/spec/polaris-management-service.yml#L937-L947) |
| `HADOOP` | `warehouse` | [`HadoopConnectionConfigInfo`](https://github.com/apache/polaris-tools/blob/e5fea020aedcb1834f306d9a13de7fccbfff1943/console/spec/polaris-management-service.yml#L949-L957) |
| `HIVE` | `warehouse` | [`HiveConnectionConfigInfo`](https://github.com/apache/polaris-tools/blob/e5fea020aedcb1834f306d9a13de7fccbfff1943/console/spec/polaris-management-service.yml#L959-L967) |

All three are selectable in the form. The server accepts the resulting catalog, so the failure is deferred to first use rather than surfacing at create time.

For `ICEBERG_REST` the consequence is concrete: the spec describes `remoteCatalogName` as translating "into a 'prefix' added to all REST resource paths", so a prefix-scoped remote rejects the proxied request and namespace listing returns `400`.

The [Iceberg REST federation docs](https://polaris.apache.org/releases/1.2.0/federation/iceberg-rest-federation/) document this as user-facing configuration — "supply it when the remote server multiplexes multiple logical catalogs under one URI" — and the CLI exposes it as `--iceberg-remote-catalog-name`. The console is the only surface that cannot set it.

Reported in #266, which has the reproduction.

## Change

Adds both fields to the flattened `ConnectionConfigInfo`, following how `StorageConfigInfo` handles the S3/Azure/GCS discriminator in the same file, and renders them conditionally on the selected connection type.

Connection type is checked in two places, for different reasons. Rendering is gated so a field only appears for the types it applies to. The payload builder filters by type as well as presence, because [`react-hook-form` retains values for unmounted fields](https://react-hook-form.com/docs/useform#shouldUnregister) by default, so a name typed under `ICEBERG_REST` would otherwise be submitted after switching to `HADOOP`.

The details page guards on presence alone. The discriminator means a response for one connection type cannot carry another's field, so a type check there would exclude nothing.

Both fields are optional and nothing existing changes behavior; the diff is additive.

## Testing

`make lint` and `make build` (which covers `format-check`) are clean.

Verified against a live Polaris 1.5.0: a federated catalog created with `remoteCatalogName` set resolves and lists namespaces, where the same catalog without it returns `400`. That was done through the management API, so it confirms the server behavior and the payload shape rather than the browser interaction.

<img width="1280" height="929" alt="image" src="https://github.com/user-attachments/assets/9c9a3692-c054-4dff-a4c8-3186726c70c3" />
<img width="1280" height="929" alt="image" src="https://github.com/user-attachments/assets/71870aa2-d2a0-459b-9c0e-9271bacc5f4f" />



`HADOOP` and `HIVE` are compile-and-render only; I have no such remote to test against. Both take the same code path as `ICEBERG_REST` apart from the field name.

## Notes

- **No spec change needed.** All three subtypes already declare these fields.
- **`EditCatalogModal` is untouched deliberately.** [`UpdateCatalogRequest`](https://github.com/apache/polaris-tools/blob/e5fea020aedcb1834f306d9a13de7fccbfff1943/console/spec/polaris-management-service.yml#L1208-L1221) accepts only `currentEntityVersion`, `properties`, and `storageConfigInfo`, so a field there would be a control that does nothing. This differs from the storage field proposed in #261, which the edit modal can handle.
- **Flattened rather than discriminated.** Proper subtypes would be more faithful to the spec, but `StorageConfigInfo` in the same file is flattened, so this follows the local convention. Happy to rework if you would rather change the pattern.
- **Connection config cannot be edited after creation**, and that is a server constraint rather than a console gap: `UpdateCatalogRequest` does not accept `connectionConfigInfo` at all. `uri` and the auth fields already had this limitation; these two inherit it.
- **The unused `icebergRemoteCatalogName` / `hadoopWarehouse` on `CreateCatalogRequest` (`api.ts:83-84`) are left alone.** They sit flat on the catalog object rather than under `connectionConfigInfo`, are never assigned, and cover only two of the three types. Removing them is a separate cleanup.
- The spec marks `ConnectionConfigInfo` experimental; that applies equally to the existing `uri` and `authenticationParameters` fields.





